### PR TITLE
Fix capitalization of the PDF/A version

### DIFF
--- a/cURL/pdfa.sh
+++ b/cURL/pdfa.sh
@@ -4,5 +4,5 @@ curl -X POST "https://api.pdfrest.com/pdfa" \
   -H "Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   -F "file=@../Sample_Input/ducky.pdf" \
   -F "output=example_out" \
-  -F "output_type=pdf/a-1b" \
+  -F "output_type=PDF/A-1b" \
   -F "rasterize_if_errors_encountered=off"


### PR DESCRIPTION
This fixes the cURL example to use the correct capitalization `PDF/A-1b`.