### PR TITLE
PDFCLOUD-1625 | Add PDF/X code samples

### DIFF
--- a/JavaScript/pdfx-endpoint.js
+++ b/JavaScript/pdfx-endpoint.js
@@ -1,4 +1,4 @@
-// This request demonstrates how to convert any of several formats to PDF/A. 
+// This request demonstrates how to convert any of several formats to PDF/X. 
 var axios = require('axios');
 var FormData = require('form-data');
 var fs = require('fs');
@@ -6,15 +6,14 @@ var fs = require('fs');
 // Create a new form data object and append the PDF file and parameters to it
 var data = new FormData();
 data.append('file', fs.createReadStream('/path/to/file'));
-data.append('output_type', 'PDF/A-2b'); 
-data.append('rasterize_if_errors_encountered', 'off');
-data.append('output', 'pdfrest_pdfa');
+data.append('output_type', 'PDF/X-4'); 
+data.append('output', 'pdfrest_pdfx');
 
 // define configuration options for axios request
 var config = {
   method: 'post',
   maxBodyLength: Infinity, // set maximum length of the request body
-  url: 'https://api.pdfrest.com/pdfa', 
+  url: 'https://api.pdfrest.com/pdfx', 
   headers: { 
     'Api-Key': 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', // Replace with your API key
     ...data.getHeaders() // set headers for the request

--- a/PHP/pdfx-endpoint.php
+++ b/PHP/pdfx-endpoint.php
@@ -1,0 +1,43 @@
+<?php
+require("../Sample_Input/sample_input.php");
+
+// The /pdfx endpoint can take a single PDF file or id as input.
+$pdfx_endpoint_url = 'https://api.pdfrest.com/pdfx';
+
+// Create an array that contains that data that will be passed to the POST request.
+$data = array(
+    'file' => new CURLFile(SAMPLE_INPUT_DIR . 'ducky.pdf','application/pdf', 'ducky.pdf'),
+    'output_type' => 'PDF/X-4',
+    'output' => 'example_pdfx_out'
+);
+
+$headers = array(
+    'Accept: application/json',
+    'Content-Type: multipart/form-data',
+    'Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' // place your api key here
+);
+
+// Initialize a cURL session.
+$ch = curl_init();
+
+// Set the url, headers, and data that will be sent to pdfx endpoint.
+curl_setopt($ch, CURLOPT_URL, $pdfx_endpoint_url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+
+print "Sending POST request to pdfx endpoint...\n";
+$response = curl_exec($ch);
+
+print "Response status code: " . curl_getinfo($ch, CURLINFO_HTTP_CODE) . "\n";
+
+if($response === false){
+    print 'Error: ' . curl_error($ch) . "\n";
+}else{
+    print json_encode(json_decode($response), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    print "\n";
+}
+
+curl_close($ch);
+?>

--- a/Python/pdfx-endpoint.py
+++ b/Python/pdfx-endpoint.py
@@ -1,0 +1,35 @@
+from requests_toolbelt import MultipartEncoder
+import requests
+import json
+
+pdfx_endpoint_url = 'https://api.pdfrest.com/pdfx'
+
+# The /pdfx endpoint can take a single PDF file or id as input.
+mp_encoder_pdfx = MultipartEncoder(
+    fields={
+        'file': ('ducky.pdf', open('../Sample_Input/ducky.pdf', 'rb'), 'application/pdf'),
+        'output_type': 'PDF/X-4',
+        'output' : 'example_pdfx_out'
+    }
+)
+
+# Let's set the headers that the pdfx endpoint expects.
+# Since MultipartEncoder is used, the 'Content-Type' header gets set to 'multipart/form-data' via the content_type attribute below.
+headers = {
+    'Accept': 'application/json',
+    'Content-Type': mp_encoder_pdfx.content_type,
+    'Api-Key': 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' # place your api key here
+}
+
+print("Sending POST request to pdfx endpoint...")
+response = requests.post(pdfx_endpoint_url, data=mp_encoder_pdfx, headers=headers)
+
+print("Response status code: " + str(response.status_code))
+
+if response.ok:
+    response_json = response.json()
+    print(json.dumps(response_json, indent = 2))
+else:
+    print(response.text)
+
+# If you would like to download the file instead of getting the JSON response, please see the 'get-resource-id-endpoint.py' sample.

--- a/cURL/pdfx.sh
+++ b/cURL/pdfx.sh
@@ -1,0 +1,7 @@
+curl -X POST "https://api.pdfrest.com/pdfx" \
+  -H "Accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -H "Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -F "file=@../Sample_Input/ducky.pdf" \
+  -F "output=example_out" \
+  -F "output_type=PDF/X-4" \


### PR DESCRIPTION
**This PR satisfies the requirements in PDFCLOUD-1625.**

Adds 4 new code samples for the `/pdfx` endpoint:
- `JavaScript/pdfx-endpoint.js`
- `PHP/pdfx-endpoint.php`
- `Python/pdfx-endpoint.py`
- `cURL/pdfx.sh`