### PR TITLE
Fix import typos

### DIFF
--- a/PHP/Single Calls/pdf-with-imported-form-data.php
+++ b/PHP/Single Calls/pdf-with-imported-form-data.php
@@ -37,4 +37,4 @@ $request = new Request('POST', 'https://api.pdfrest.com/pdf-with-imported-form-d
 
 $res = $client->sendAsync($request, $options)->wait(); // Send the asynchronous request and wait for the response.
 
-echo $res->getBody(); // Output the response body, which contains the flattened PDF with forms .
+echo $res->getBody(); // Output the response body, which contains the PDF with data.

--- a/cURL/Single Calls/pdf-with-imported-form-data.sh
+++ b/cURL/Single Calls/pdf-with-imported-form-data.sh
@@ -4,4 +4,4 @@ curl -X POST "https://api.pdfrest.com/pdf-with-imported-form-data" \
   -H "Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   -F "file=@/path/to/file" \
   -F "output=example_out" \
-  -F "data_file=@/path/to/datafile" \
+  -F "data_file=@/path/to/datafile"


### PR DESCRIPTION
These were fixed on the site, except for where they are pulled from GitHub.