### PR TITLE
PDFCLOUD-2652 Add filename extensions to the python samples

### DIFF
--- a/Python/Endpoint Examples/Multipart Payload/bmp.py
+++ b/Python/Endpoint Examples/Multipart Payload/bmp.py
@@ -8,7 +8,7 @@ bmp_endpoint_url = 'https://api.pdfrest.com/bmp'
 # This sample takes in a PDF and converts all pages into grayscale BMP files.
 mp_encoder_bmp = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'pages': '1-last',
         'resolution': '600',
         'color_model': 'gray',

--- a/Python/Endpoint Examples/Multipart Payload/compressed-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/compressed-pdf.py
@@ -9,7 +9,7 @@ compressed_pdf_endpoint_url = 'https://api.pdfrest.com/compressed-pdf'
 # We have preset 'high', 'medium', and 'low' compression levels available for use. These preset levels do not require the 'profile' parameter.
 mp_encoder_compressedPdf = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_compressedPdf_out',
         'compression_level': 'medium',
     }

--- a/Python/Endpoint Examples/Multipart Payload/decrypted-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/decrypted-pdf.py
@@ -8,7 +8,7 @@ decrypted_pdf_endpoint_url = 'https://api.pdfrest.com/decrypted-pdf'
 # This sample demonstrates decryption of a PDF with the password 'password'.
 mp_encoder_decryptedPdf = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_decryptedPdf_out',
         'current_open_password': 'password',
     }

--- a/Python/Endpoint Examples/Multipart Payload/encrypted-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/encrypted-pdf.py
@@ -8,7 +8,7 @@ encrypted_pdf_endpoint_url = 'https://api.pdfrest.com/encrypted-pdf'
 # This sample demonstrates encryption of a PDF with the password 'password'.
 mp_encoder_encryptedPdf = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_encryptedPdf_out',
         'new_open_password': 'password',
     }

--- a/Python/Endpoint Examples/Multipart Payload/exported-form-data.py
+++ b/Python/Endpoint Examples/Multipart Payload/exported-form-data.py
@@ -8,7 +8,7 @@ exported_form_data_endpoint_url = 'https://api.pdfrest.com/exported-form-data'
 # This sample demonstrates encryption of a PDF with the password 'password'.
 mp_encoder_exportedFormData = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_exportedFormData_out',
         'data_format': 'xml',
     }

--- a/Python/Endpoint Examples/Multipart Payload/extracted-text.py
+++ b/Python/Endpoint Examples/Multipart Payload/extracted-text.py
@@ -8,7 +8,7 @@ extract_text_endpoint_url = 'https://api.pdfrest.com/extracted-text'
 #This sample demonstrates extracting the text from a document to return as JSON
 mp_encoder_extractText = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
     }
 )
 

--- a/Python/Endpoint Examples/Multipart Payload/flattened-annotations-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/flattened-annotations-pdf.py
@@ -6,7 +6,7 @@ flattened_annotations_pdf_endpoint_url = 'https://api.pdfrest.com/flattened-anno
 
 mp_encoder_flattenedPDF = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_out'
     }
 )

--- a/Python/Endpoint Examples/Multipart Payload/flattened-forms-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/flattened-forms-pdf.py
@@ -6,7 +6,7 @@ flattened_forms_pdf_endpoint_url = 'https://api.pdfrest.com/flattened-forms-pdf'
 
 mp_encoder_flattenedPDF = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_out'
     }
 )

--- a/Python/Endpoint Examples/Multipart Payload/flattened-layers-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/flattened-layers-pdf.py
@@ -6,7 +6,7 @@ flattened_layers_pdf_endpoint_url = 'https://api.pdfrest.com/flattened-layers-pd
 
 mp_encoder_flattenedPDF = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_out'
     }
 )

--- a/Python/Endpoint Examples/Multipart Payload/flattened-transparencies-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/flattened-transparencies-pdf.py
@@ -9,7 +9,7 @@ flatten_transparencies_pdf_endpoint_url = 'https://api.pdfrest.com/flattened-tra
 # We have preset 'high', 'medium', and 'low' quality levels available for use. These preset levels do not require the 'profile' parameter.
 mp_encoder_flattenTransparenciesPdf = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_flattenedPdf_out',
         'quality': 'medium',
     }

--- a/Python/Endpoint Examples/Multipart Payload/gif.py
+++ b/Python/Endpoint Examples/Multipart Payload/gif.py
@@ -8,7 +8,7 @@ gif_endpoint_url = 'https://api.pdfrest.com/gif'
 # This sample takes in a PDF and converts all pages into grayscale GIF files.
 mp_encoder_gif = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'pages': '1-last',
         'resolution': '600',
         'color_model': 'gray',

--- a/Python/Endpoint Examples/Multipart Payload/jpg.py
+++ b/Python/Endpoint Examples/Multipart Payload/jpg.py
@@ -8,7 +8,7 @@ jpg_endpoint_url = 'https://api.pdfrest.com/jpg'
 # This sample takes in a PDF and converts all pages into JPEG files.
 mp_encoder_jpg = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'pages': '1-last',
         'resolution': '600',
         'color_model': 'cmyk',

--- a/Python/Endpoint Examples/Multipart Payload/linearized-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/linearized-pdf.py
@@ -8,7 +8,7 @@ linearized_pdf_endpoint_url = 'https://api.pdfrest.com/linearized-pdf'
 # This sample demonstrates linearizing a PDF file.
 mp_encoder_linearizedPdf = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_linearizedPdf_out',
     }
 )

--- a/Python/Endpoint Examples/Multipart Payload/merged-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/merged-pdf.py
@@ -11,8 +11,8 @@ merge_request_data = []
 
 # Array of tuples that contains information about the 2 files that will be merged
 files = [
-    ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
-    ('file_name', open('/path/to/file', 'rb'), 'application/pdf')
+    ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
+    ('file_name2.pdf', open('/path/to/file', 'rb'), 'application/pdf')
 ]
 
 # Structure the data that will be sent to POST merge request as an array of tuples

--- a/Python/Endpoint Examples/Multipart Payload/pdf-info.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-info.py
@@ -8,7 +8,7 @@ pdf_info_endpoint_url = 'https://api.pdfrest.com/pdf-info'
 #This sample demonstrates querying the title, page count, document language and author
 mp_encoder_pdfInfo = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'queries': 'title,page_count,doc_language,author',
     }
 )

--- a/Python/Endpoint Examples/Multipart Payload/pdf-with-added-image.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-with-added-image.py
@@ -6,8 +6,8 @@ pdf_with_added_image_endpoint_url = 'https://api.pdfrest.com/pdf-with-added-imag
 
 mp_encoder_pdfWithAddedImage = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
-        'image_file': ('file_name', open('/path/to/file', 'rb'), 'image/jpeg'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
+        'image_file': ('file_name.jpg', open('/path/to/file', 'rb'), 'image/jpeg'),
         'output' : 'example_out',
         'x' : '10',
         'y' : '10',

--- a/Python/Endpoint Examples/Multipart Payload/pdf-with-imported-form-data.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-with-imported-form-data.py
@@ -6,8 +6,8 @@ import_form_data_endpoint_url = 'https://api.pdfrest.com/pdf-with-imported-form-
 
 mp_encoder_importFormData = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
-        'data_file': ('file_name', open('/path/to/datafile', 'rb'), 'application/xml'), # Update for your data file format
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
+        'data_file': ('file_name.xml', open('/path/to/datafile', 'rb'), 'application/xml'), # Update for your data file format
         'output' : 'example_out'
     }
 )

--- a/Python/Endpoint Examples/Multipart Payload/pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf.py
@@ -10,7 +10,7 @@ pdf_endpoint_url = 'https://api.pdfrest.com/pdf'
 # Please see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types for more information about MIME types.
 mp_encoder_pdf = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'image/tiff'),
+        'file': ('file_name.tif', open('/path/to/file', 'rb'), 'image/tiff'),
         'output' : 'example_pdf_out',
     }
 )

--- a/Python/Endpoint Examples/Multipart Payload/pdfa.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdfa.py
@@ -7,7 +7,7 @@ pdfa_endpoint_url = 'https://api.pdfrest.com/pdfa'
 # The /pdfa endpoint can take a single PDF file or id as input.
 mp_encoder_pdfa = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output_type': 'PDF/A-1b',
         'rasterize_if_errors_encountered': 'on',
         'output' : 'example_pdfa_out',

--- a/Python/Endpoint Examples/Multipart Payload/pdfx.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdfx.py
@@ -7,7 +7,7 @@ pdfx_endpoint_url = 'https://api.pdfrest.com/pdfx'
 # The /pdfx endpoint can take a single PDF file or id as input.
 mp_encoder_pdfx = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output_type': 'PDF/X-4',
         'output' : 'example_pdfx_out'
     }

--- a/Python/Endpoint Examples/Multipart Payload/png.py
+++ b/Python/Endpoint Examples/Multipart Payload/png.py
@@ -8,7 +8,7 @@ png_endpoint_url = 'https://api.pdfrest.com/png'
 # This sample takes in a PDF and converts all pages into grayscale PNG files.
 mp_encoder_png = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'pages': '1-last',
         'resolution': '600',
         'color_model': 'gray',

--- a/Python/Endpoint Examples/Multipart Payload/restricted-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/restricted-pdf.py
@@ -8,7 +8,7 @@ restricted_pdf_endpoint_url = 'https://api.pdfrest.com/restricted-pdf'
 # This sample demonstrates setting the permissions password to 'password' and adding restrictions.
 mp_encoder_restrictedPdf = MultipartEncoder(
     fields=[
-        ('file', ('file_name', open('/path/to/file', 'rb'), 'application/pdf')),
+        ('file', ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf')),
         ('output', 'example_restrictedPdf_out'),
         ('new_permissions_password', 'password'),
         ('restrictions', 'print_high'),

--- a/Python/Endpoint Examples/Multipart Payload/split-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/split-pdf.py
@@ -9,7 +9,7 @@ split_pdf_endpoint_url = 'https://api.pdfrest.com/split-pdf'
 
 # Create a list of tuples for data that will be sent to the request
 split_request_data = []
-split_request_data.append(('file',('file_name', open('/path/to/file', 'rb'), 'application/pdf')))
+split_request_data.append(('file',('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf')))
 split_request_data.append(('pages', '1,2,5'))
 split_request_data.append(('pages', '3,4'))
 split_request_data.append(('output', 'example_splitPdf_out'))

--- a/Python/Endpoint Examples/Multipart Payload/tif.py
+++ b/Python/Endpoint Examples/Multipart Payload/tif.py
@@ -8,7 +8,7 @@ tif_endpoint_url = 'https://api.pdfrest.com/tif'
 # This sample takes in a PDF and converts all pages into grayscale TIFF files.
 mp_encoder_tif = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'pages': '1-last',
         'resolution': '600',
         'color_model': 'gray',

--- a/Python/Endpoint Examples/Multipart Payload/unrestricted-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/unrestricted-pdf.py
@@ -8,7 +8,7 @@ unrestricted_pdf_endpoint_url = 'https://api.pdfrest.com/unrestricted-pdf'
 # This sample demonstrates removing security restrictions from a PDF.
 mp_encoder_unrestrictedPdf = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'output' : 'example_unrestrictedPdf_out',
         'current_permissions_password': 'password'
     }

--- a/Python/Endpoint Examples/Multipart Payload/upload.py
+++ b/Python/Endpoint Examples/Multipart Payload/upload.py
@@ -12,9 +12,9 @@ upload_request_data = []
 # The 'application/pdf' string below is known as a MIME type, which is a label used to identify the type of a file so that it is handled properly by software.
 # Please see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types for more information about MIME types.
 files = [
-    ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
-    ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
-    ('file_name', open('/path/to/file', 'rb'), 'image/jpeg')
+    ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
+    ('file_name2.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
+    ('file_name.jpg', open('/path/to/file', 'rb'), 'image/jpeg')
 ]
 
 # Structure the data that will be sent to POST upload request as an array of tuples

--- a/Python/Endpoint Examples/Multipart Payload/watermarked-pdf.py
+++ b/Python/Endpoint Examples/Multipart Payload/watermarked-pdf.py
@@ -6,7 +6,7 @@ watermarked_pdf_endpoint_url = 'https://api.pdfrest.com/watermarked-pdf'
 
 mp_encoder_watermarkedPDF = MultipartEncoder(
     fields={
-        'file': ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
+        'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
         'watermark_text': 'watermark',
         'output' : 'example_out'
     }

--- a/Python/Endpoint Examples/Multipart Payload/zip.py
+++ b/Python/Endpoint Examples/Multipart Payload/zip.py
@@ -12,9 +12,9 @@ zip_request_data = []
 # The 'application/pdf' string below is known as a MIME type, which is a label used to identify the type of a file so that it is handled properly by software.
 # Please see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types for more information about MIME types.
 files = [
-    ('file_name', open('/path/to/file', 'rb'), 'application/pdf'),
-    ('file_name', open('/path/to/file', 'rb'), 'image/tiff'),
-    ('file_name', open('/path/to/file', 'rb'), 'image/bmp')
+    ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
+    ('file_name.tif', open('/path/to/file', 'rb'), 'image/tiff'),
+    ('file_name.bmp', open('/path/to/file', 'rb'), 'image/bmp')
 ]
 
 # Structure the data that will be sent to POST zip request as an array of tuples


### PR DESCRIPTION
Just to make it clearer that these names need to be filled out with the extension as well as making the samples run more smoothly if the user does not fill out the filename section and just leaves the default