### PR TITLE
Add optional parameters to code samples

### DIFF
--- a/DotNET/Endpoint Examples/Multipart Payload/exported-form-data.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/exported-form-data.cs
@@ -16,6 +16,9 @@ using (var httpClient = new HttpClient { BaseAddress = new Uri("https://api.pdfr
         var byteArrayOption = new ByteArrayContent(Encoding.UTF8.GetBytes("xml"));
         multipartContent.Add(byteArrayOption, "data_format");
 
+        var byteArrayOption2 = new ByteArrayContent(Encoding.UTF8.GetBytes("extracted"));
+        multipartContent.Add(byteArrayOption2, "output");
+
 
         request.Content = multipartContent;
         var response = await httpClient.SendAsync(request);

--- a/DotNET/Endpoint Examples/Multipart Payload/extracted-text.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/extracted-text.cs
@@ -13,6 +13,9 @@ using (var httpClient = new HttpClient { BaseAddress = new Uri("https://api.pdfr
         multipartContent.Add(byteAryContent, "file", "file_name");
         byteAryContent.Headers.TryAddWithoutValidation("Content-Type", "application/pdf");
 
+        var byteArrayOption = new ByteArrayContent(Encoding.UTF8.GetBytes("on"));
+        multipartContent.Add(byteArrayOption, "word_style");
+
 
         request.Content = multipartContent;
         var response = await httpClient.SendAsync(request);

--- a/DotNET/Endpoint Examples/Multipart Payload/merged-pdf.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/merged-pdf.cs
@@ -29,6 +29,9 @@ using (var httpClient = new HttpClient { BaseAddress = new Uri("https://api.pdfr
         var byteArrayOption4 = new ByteArrayContent(Encoding.UTF8.GetBytes("all"));
         multipartContent.Add(byteArrayOption4, "pages[]");
 
+        var byteArrayOption5 = new ByteArrayContent(Encoding.UTF8.GetBytes("merged"));
+        multipartContent.Add(byteArrayOption5, "output");
+
         request.Content = multipartContent;
         var response = await httpClient.SendAsync(request);
 

--- a/DotNET/Endpoint Examples/Multipart Payload/split-pdf.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/split-pdf.cs
@@ -19,6 +19,9 @@ using (var httpClient = new HttpClient { BaseAddress = new Uri("https://api.pdfr
         var byteArrayOption2 = new ByteArrayContent(Encoding.UTF8.GetBytes("2-last"));
         multipartContent.Add(byteArrayOption2, "pages[]");
 
+        var byteArrayOption3 = new ByteArrayContent(Encoding.UTF8.GetBytes("split"));
+        multipartContent.Add(byteArrayOption3, "output");
+
 
         request.Content = multipartContent;
         var response = await httpClient.SendAsync(request);

--- a/DotNET/Endpoint Examples/Multipart Payload/word.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/word.cs
@@ -13,6 +13,9 @@ using (var httpClient = new HttpClient { BaseAddress = new Uri("https://api.pdfr
         multipartContent.Add(byteAryContent, "file", "file_name");
         byteAryContent.Headers.TryAddWithoutValidation("Content-Type", "application/pdf");
 
+        var byteArrayOption = new ByteArrayContent(Encoding.UTF8.GetBytes("converted"));
+        multipartContent.Add(byteArrayOption, "output");
+
 
         request.Content = multipartContent;
         var response = await httpClient.SendAsync(request);

--- a/JavaScript/Endpoint Examples/Multipart Payload/extracted-text.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/extracted-text.js
@@ -6,6 +6,7 @@ var fs = require("fs");
 // Create a new form data instance and append the PDF file and parameters to it
 var data = new FormData();
 data.append("file", fs.createReadStream("/path/to/file"));
+data.append("word_style", "on");
 
 // define configuration options for axios request
 var config = {

--- a/PHP/Endpoint Examples/Multipart Payload/extracted-text.php
+++ b/PHP/Endpoint Examples/Multipart Payload/extracted-text.php
@@ -20,6 +20,10 @@ $options = [
       'headers' => [
         'Content-Type' => '<Content-type header>' // Set the Content-Type header for the file.
       ]
+    ],
+    [
+      'name' => 'word_style', // Specify the field name for the word_style option.
+      'contents' => 'on' // Set the value for the output option (in this case, 'on').
     ]
   ]
 ];

--- a/Python/Endpoint Examples/Multipart Payload/extracted-text.py
+++ b/Python/Endpoint Examples/Multipart Payload/extracted-text.py
@@ -9,6 +9,7 @@ extract_text_endpoint_url = 'https://api.pdfrest.com/extracted-text'
 mp_encoder_extractText = MultipartEncoder(
     fields={
         'file': ('file_name.pdf', open('/path/to/file', 'rb'), 'application/pdf'),
+        'word_style': 'on',
     }
 )
 


### PR DESCRIPTION
We wanted to add some optional arguments to the following samples 

- split-pdf
- extracted-text
- merged-pdf
- exported-form-data
- word

for C#, Javascript, PHP and Python

A number of the samples already used optional arguments, but a few needed touching up