### PR TITLE
Add polling retries to samples that lacked it

### DIFF
--- a/JavaScript/Endpoint Examples/Multipart Payload/request-status.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/request-status.js
@@ -2,42 +2,59 @@ const axios = require("axios");
 const FormData = require("form-data");
 const fs = require("fs");
 
-
 const apiKey = "xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"; // Replace with your API key
 const pathToFile = "/path/to/file.pdf";
 
-let bmpRequestData = new FormData();
-bmpRequestData.append("file", fs.createReadStream(pathToFile));
 
-let bmpConfig = {
-  method: "post",
-  maxBodyLength: Infinity,
-  url: "https://api.pdfrest.com/bmp",
-  headers: {
-    "Api-Key": apiKey,
-    "Response-Type": "requestId", // Use this header to get a request ID.
-    ...bmpRequestData.getHeaders(),
-  },
-  data: bmpRequestData,
+const sleep = (ms) => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const sendBmpReq = async (config) => {
+  return await axios(config);
 };
 
-axios(bmpConfig)
-  .then(bmpResponse => {
+const pollUntilFulfilled = async (requestId) => {
+  const pollConfig = {
+    method: "get",
+    maxBodyLength: Infinity, // set maximum length of the request body
+    url: `https://api.pdfrest.com/request-status/${requestId}`,
+    headers: { "Api-Key": apiKey }
+  };
+  requestStatusResponse = await axios(pollConfig);
+  let status = requestStatusResponse.data.status;
+  while (status === "pending") {
+    console.log(JSON.stringify(requestStatusResponse.data));
+    await sleep(5000);
+    requestStatusResponse = await axios(pollConfig);
+    status = requestStatusResponse.data.status;
+  }
+  console.log(JSON.stringify(requestStatusResponse.data));
+};
+
+const demoApiPolling = async () => {
+  try {
+    const bmpRequestData = new FormData();
+    bmpRequestData.append("file", fs.createReadStream(pathToFile));
+  
+    const bmpConfig = {
+      method: "post",
+      maxBodyLength: Infinity,
+      url: "https://api.pdfrest.com/bmp",
+      headers: {
+        "Api-Key": apiKey,
+        "Response-Type": "requestId", // Use this header to get a request ID.
+        ...bmpRequestData.getHeaders(),
+      },
+      data: bmpRequestData,
+    };
+    bmpResponse = await sendBmpReq(bmpConfig);
     console.log(JSON.stringify(bmpResponse.data));
     const requestId = bmpResponse.data.requestId;
-    let config = {
-      method: "get",
-      maxBodyLength: Infinity, // set maximum length of the request body
-      url: `https://api.pdfrest.com/request-status/${requestId}`,
-      headers: { "Api-Key": apiKey }
-    };
-    axios.request(config)
-      .then((requestStatusResponse) => {
-        console.log(JSON.stringify(requestStatusResponse.data));
-      })
-      .catch((error) => {
-        console.log(error);
-    });
-  }).catch(error => {
-    console.log(error);
-  })
+    await pollUntilFulfilled(requestId);
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+demoApiPolling();

--- a/PHP/Endpoint Examples/Multipart Payload/request-status.php
+++ b/PHP/Endpoint Examples/Multipart Payload/request-status.php
@@ -46,6 +46,17 @@ $request = new Request('GET', $request_status_endpoint_url, $headers);
 
 $res = $client->sendAsync($request)->wait();
 
-echo $res->getBody(); // Output the response body, which contains the status information.
+$status = json_decode($res->getBody())->{'status'};
+
+while (strcmp($status, "pending") == 0):
+  echo $res->getBody(); // Output the response body, which contains the status information.
+  echo "\r\n";
+  sleep(5);
+  $res = $client->sendAsync($request)->wait();
+  $status = json_decode($res->getBody())->{'status'};
+endwhile;
+
+echo $res->getBody();
 echo "\r\n";
+
 ?>

--- a/Python/Endpoint Examples/Multipart Payload/request-status.py
+++ b/Python/Endpoint Examples/Multipart Payload/request-status.py
@@ -1,6 +1,7 @@
 from requests_toolbelt import MultipartEncoder
 import requests
 import json
+import time
 
 api_key = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' # place your api key here
 
@@ -42,6 +43,11 @@ if response.ok:
 
     if response.ok:
         response_json = response.json()
+        while response_json["status"] == "pending":
+            print(json.dumps(response_json, indent = 2))
+            time.sleep(5)
+            response = requests.get(api_polling_endpoint_url, headers=headers)
+            response_json = response.json()
         print(json.dumps(response_json, indent = 2))
     else:
         print(response.text)

--- a/cURL/Endpoint Examples/Multipart Payload/request-status.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/request-status.sh
@@ -12,5 +12,16 @@ REQUEST_ID=$(curl -X POST "https://api.pdfrest.com/pdfa" \
   -F "output=example_out" \
   | jq -r '.requestId')
 
-curl -X GET "https://api.pdfrest.com/request-status/$REQUEST_ID" \
-  -H "Api-Key: $API_KEY"
+RESPONSE=$(curl -X GET "https://api.pdfrest.com/request-status/$REQUEST_ID" \
+  -H "Api-Key: $API_KEY")
+echo $RESPONSE
+STATUS=$(echo $RESPONSE | jq -r '.status')
+
+while [ $STATUS = "pending" ]
+do
+  sleep 5
+  RESPONSE=$(curl -X GET "https://api.pdfrest.com/request-status/$REQUEST_ID" \
+  -H "Api-Key: $API_KEY")
+  echo $RESPONSE
+  STATUS=$(echo $RESPONSE | jq -r '.status')
+done


### PR DESCRIPTION
The Java and .NET samples that demonstrate API polling, when run, retry every 5 seconds until the request status moves from "pending". By contrast, the equivalent samples in other languages simply print the first response from `/request-status` and leave it there.

With these changes, each API polling sample will send the request every 5 seconds while the status is "pending."