### PR TITLE
Update minimum Node recommendation to Node 20

### DIFF
--- a/JavaScript/README.md
+++ b/JavaScript/README.md
@@ -3,7 +3,7 @@ as more advanced workflows presented in Javascript
 
 #### How to run JavaScript samples
 
-Using Node 16 or greater:
+We recommend using Node.js >= 20 with our code samples.
 
 1. `cd JavaScript/`
 2. `npm install node-fetch`


### PR DESCRIPTION
The currently recommended Node 16 is out of support. Node 20 is scheduled for maintenance thru mid-2026 and appears to work with our samples.