### PR TITLE
PDFCLOUD-5202 Add Ruby examples for pdfRest API integration

### DIFF
--- a/Ruby/.env.example
+++ b/Ruby/.env.example
@@ -1,3 +1,11 @@
+## Required: pdfRest API key
+# Obtain from your pdfRest dashboard. Keep this secret.
 PDFREST_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-# Optional: Override API base URL (default https://api.pdfrest.com)
+
+## Optional: Override API base URL/region
+# If unset, scripts default to the US endpoint: https://api.pdfrest.com
+# To route calls to the EU region (for GDPR compliance and lower latency in Europe), set:
 # PDFREST_URL=https://eu-api.pdfrest.com/
+# Notes:
+# - Trailing slash is optional; scripts handle it.
+# - Leave commented to use the default US endpoint.

--- a/Ruby/.env.example
+++ b/Ruby/.env.example
@@ -6,6 +6,7 @@ PDFREST_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 # If unset, scripts default to the US endpoint: https://api.pdfrest.com
 # To route calls to the EU region (for GDPR compliance and lower latency in Europe), set:
 # PDFREST_URL=https://eu-api.pdfrest.com/
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
 # Notes:
 # - Trailing slash is optional; scripts handle it.
 # - Leave commented to use the default US endpoint.

--- a/Ruby/.env.example
+++ b/Ruby/.env.example
@@ -1,0 +1,1 @@
+PDFREST_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/Ruby/.env.example
+++ b/Ruby/.env.example
@@ -1,1 +1,3 @@
 PDFREST_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# Optional: Override API base URL (default https://api.pdfrest.com)
+# PDFREST_URL=https://eu-api.pdfrest.com/

--- a/Ruby/.gitignore
+++ b/Ruby/.gitignore
@@ -1,0 +1,66 @@
+# Created by https://www.toptal.com/developers/gitignore/api/ruby
+# Edit at https://www.toptal.com/developers/gitignore?templates=ruby
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+# End of https://www.toptal.com/developers/gitignore/api/ruby
+
+## Patches
+
+# Used by dotenv library to load environment variables.
+.env

--- a/Ruby/AGENTS.md
+++ b/Ruby/AGENTS.md
@@ -19,7 +19,7 @@
 - Ruby style: 2-space indentation, `snake_case` for files, methods, and variables.
 - Script naming: match pdfRest endpoint (e.g., `markdown.rb`, `rasterized-pdf.rb`).
 - Env config: load via `dotenv`; read `PDFREST_API_KEY` and abort with clear messages.
-- HTTP: use `Faraday` with `:retry` (short, limited retries). Prefer explicit headers and content types.
+- HTTP: use `Faraday` with `:retry` (short, limited retries). Prefer explicit headers and content types. Base URL from `ENV['PDFREST_URL']` (defaults to `https://api.pdfrest.com`).
 - Errors: `abort` on non-2xx with concise context; print API responses to stdout.
 
 ## Testing Guidelines
@@ -37,3 +37,4 @@
 - Keep secrets out of VCS: do not commit `.env`; use `.env.example` as a template.
 - Handle proxies via standard env vars (e.g., `HTTPS_PROXY`) when needed.
 - Never log API keys; prefer printing only response bodies and minimal diagnostics to `STDERR`.
+- API base override: set `PDFREST_URL` in `.env` to change regions. For EU GDPR compliance and improved performance in Europe, you may use `https://eu-api.pdfrest.com/`. More info: https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work

--- a/Ruby/AGENTS.md
+++ b/Ruby/AGENTS.md
@@ -38,3 +38,50 @@
 - Handle proxies via standard env vars (e.g., `HTTPS_PROXY`) when needed.
 - Never log API keys; prefer printing only response bodies and minimal diagnostics to `STDERR`.
 - API base override: set `PDFREST_URL` in `.env` to change regions. For EU GDPR compliance and improved performance in Europe, you may use `https://eu-api.pdfrest.com/`. More info: https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+
+---
+
+## Audience And Tone (Internal)
+
+These samples are customer‑facing and intended to help potential customers evaluate pdfRest quickly. Keep all code, comments, and documentation clear, minimal, and task‑focused. Avoid internal jargon and advanced implementation details in customer‑visible files. Do not surface internal process notes in `README.md` or the samples.
+
+Key points:
+- Clarity: explain what the sample does in 1–2 bullets.
+- Guidance: show how to set up `.env` and how to run the script.
+- Region: mention optional `PDFREST_URL` with the EU endpoint for GDPR and proximity.
+- Safety: never log secrets; print only response bodies and minimal diagnostics to `STDERR`.
+- Errors: abort on non‑2xx with a concise message; exit non‑zero.
+
+## Sample Header Convention (Internal)
+
+Add this standardized header comment at the top of every Ruby sample. This header is customer‑visible but the convention itself is for us to remember here (do not duplicate these instructions in README).
+
+Template:
+
+```
+#!
+# What this sample does:
+# - <One–two bullets describing purpose and request style>
+#
+# Setup (.env):
+# - Copy .env.example to .env
+# - Set PDFREST_API_KEY=your_api_key_here
+# - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+#     PDFREST_URL=https://eu-api.pdfrest.com
+#
+# Usage:
+#   ruby "<relative path to this file>" /path/to/input.pdf
+#
+# Output:
+# - Prints the API JSON response to stdout. Non-2xx responses abort with a concise message.
+# - Tip: pipe output to a file: ruby ... > response.json
+```
+
+Notes:
+- Match the endpoint name and request style (JSON two‑step vs multipart single request) in the bullets.
+- Keep the header concise; avoid adding options unless they are essential.
+- If a sample accepts optional parameters, mention them inline in code near where they are used.
+
+## README Scope (Internal)
+
+Keep `README.md` focused on user setup, running samples, and high‑level background. Avoid internal conventions or meta‑process content that could confuse customers. Place internal notes and templates in `AGENTS.md` (this file).

--- a/Ruby/AGENTS.md
+++ b/Ruby/AGENTS.md
@@ -68,6 +68,7 @@ Template:
 # - Set PDFREST_API_KEY=your_api_key_here
 # - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
 #     PDFREST_URL=https://eu-api.pdfrest.com
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
 #
 # Usage:
 #   ruby "<relative path to this file>" /path/to/input.pdf

--- a/Ruby/AGENTS.md
+++ b/Ruby/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `Endpoint Examples/JSON Payload/`: Two-step samples (upload then operate), e.g., `markdown.rb`.
+- `Endpoint Examples/Multipart Payload/`: Single multipart request samples, e.g., `rasterized-pdf.rb`.
+- `Gemfile` and `Gemfile.lock`: Dependencies (`faraday`, `faraday-multipart`, `faraday-retry`, `dotenv`).
+- `.env.example` → copy to `.env` and set `PDFREST_API_KEY`.
+- `README.md`: Setup, usage, and background details.
+
+## Build, Test, and Development Commands
+- Install Ruby (via rbenv): `rbenv install 3.4.4 && rbenv local 3.4.4`.
+- Install deps: `bundle install`.
+- Update deps: `bundle update`.
+- Run JSON sample: `ruby "Endpoint Examples/JSON Payload/markdown.rb" /path/to/input.pdf`.
+- Run Multipart sample: `ruby "Endpoint Examples/Multipart Payload/rasterized-pdf.rb" /path/to/input.pdf`.
+- Tip: Pipe output to a file: `... > response.json`.
+
+## Coding Style & Naming Conventions
+- Ruby style: 2-space indentation, `snake_case` for files, methods, and variables.
+- Script naming: match pdfRest endpoint (e.g., `markdown.rb`, `rasterized-pdf.rb`).
+- Env config: load via `dotenv`; read `PDFREST_API_KEY` and abort with clear messages.
+- HTTP: use `Faraday` with `:retry` (short, limited retries). Prefer explicit headers and content types.
+- Errors: `abort` on non-2xx with concise context; print API responses to stdout.
+
+## Testing Guidelines
+- No formal test suite (RSpec) present. Validate by running samples against known inputs.
+- Success criteria: non-zero exit on failures; JSON printed to stdout on success.
+- Add samples consistently: accept input path as first argument; document optional params inline.
+
+## Commit & Pull Request Guidelines
+- Commits: imperative mood and focused scope (e.g., "Add multipart markdown sample").
+- Include what changed and why; reference endpoint and path.
+- PRs: clear description, run commands used for verification, expected response snippet, and any notes on options.
+- Link related issues; avoid unrelated changes.
+
+## Security & Configuration Tips
+- Keep secrets out of VCS: do not commit `.env`; use `.env.example` as a template.
+- Handle proxies via standard env vars (e.g., `HTTPS_PROXY`) when needed.
+- Never log API keys; prefer printing only response bodies and minimal diagnostics to `STDERR`.

--- a/Ruby/Complex Flow Examples/merge-different-file-types.rb
+++ b/Ruby/Complex Flow Examples/merge-different-file-types.rb
@@ -1,0 +1,118 @@
+require "json"
+require "faraday"
+require "faraday/retry"
+require "faraday/multipart"
+require "dotenv"
+require "cgi"
+
+# In this sample, we demonstrate how to merge different file types together,
+# inspired by the PHP example at ../PHP/Complex Flow Examples/merge-different-file-types.php
+# and the solution described at https://pdfrest.com/solutions/merge-multiple-types-of-files-together/.
+#
+# Flow:
+# 1) For each input path provided on the command line:
+#    - If the input is NOT a PDF, convert it to PDF via the /pdf endpoint and capture its outputId.
+#    - If the input IS a PDF, do not reconvert; upload it to /upload and capture the returned file id.
+# 2) Pass all collected IDs to /merged-pdf with matching pages[]=1-last and type[]=id entries.
+#
+# Notes:
+# - Set PDFREST_API_KEY in .env (dotenv loads it). Optionally set PDFREST_URL to override the base URL
+#   (defaults to https://api.pdfrest.com). See README for EU/GDPR endpoint details.
+
+Dotenv.load
+
+API_KEY = ENV["PDFREST_API_KEY"]
+abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
+
+# Allow overriding the API base URL via .env (default to US endpoint)
+API_BASE = (ENV["PDFREST_URL"] || ENV["PDFREST_API"] || "https://api.pdfrest.com").sub(%r{/+$}, "")
+
+paths = ARGV
+if paths.length < 2 || paths.any? { |p| !File.file?(p) }
+  abort("Usage: ruby merge-different-file-types.rb /path/to/file1 /path/to/file2 [/path/to/file3 ...]")
+end
+
+def content_type_for(path)
+  ext = File.extname(path).downcase
+  case ext
+  when ".pdf" then "application/pdf"
+  when ".png" then "image/png"
+  when ".jpg", ".jpeg" then "image/jpeg"
+  when ".gif" then "image/gif"
+  when ".tif", ".tiff" then "image/tiff"
+  when ".bmp" then "image/bmp"
+  when ".webp" then "image/webp"
+  when ".doc" then "application/msword"
+  when ".docx" then "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  when ".ppt" then "application/vnd.ms-powerpoint"
+  when ".pptx" then "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+  when ".xls" then "application/vnd.ms-excel"
+  when ".xlsx" then "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  when ".txt" then "text/plain"
+  when ".rtf" then "application/rtf"
+  when ".html", ".htm" then "text/html"
+  else "application/octet-stream"
+  end
+end
+
+begin
+  conn = Faraday.new(url: API_BASE) do |f|
+    f.request :retry, max: 2, interval: 0.2
+    f.request :multipart
+    f.adapter Faraday.default_adapter
+  end
+
+  # Collect IDs for merge (from either /pdf or /upload)
+  collected_ids = []
+  paths.each_with_index do |p, idx|
+    if File.extname(p).downcase == ".pdf"
+      # Already a PDF: upload to get an id
+      upload_resp = conn.post("/upload") do |req|
+        req.headers["api-key"] = API_KEY
+        req.headers["content-filename"] = File.basename(p)
+        req.headers["Content-Type"] = "application/octet-stream"
+        req.body = File.binread(p)
+      end
+      STDERR.puts upload_resp.body
+      abort("Upload failed for input ##{idx + 1} with status #{upload_resp.status}") unless upload_resp.success?
+      upload_json = JSON.parse(upload_resp.body)
+      collected_ids << upload_json.fetch("files").fetch(0).fetch("id")
+      STDERR.puts "Uploaded PDF (##{idx + 1}); id=#{collected_ids.last}"
+    else
+      # Not a PDF: convert to PDF via /pdf to get an outputId
+      ct = content_type_for(p)
+      part = Faraday::Multipart::FilePart.new(p, ct, File.basename(p))
+      conv_resp = conn.post("/pdf") do |req|
+        req.headers["api-key"] = API_KEY
+        req.body = { file: part }
+      end
+      STDERR.puts conv_resp.body
+      abort("Conversion failed for input ##{idx + 1} with status #{conv_resp.status}") unless conv_resp.success?
+      collected_ids << JSON.parse(conv_resp.body).fetch("outputId")
+      STDERR.puts "Converted non-PDF (##{idx + 1}); outputId=#{collected_ids.last}"
+    end
+  end
+
+  # Build merge parameters for all inputs
+  # Build urlencoded body to avoid multipart array encoding issues
+  form_parts = []
+  collected_ids.each do |id|
+    form_parts << "id[]=#{CGI.escape(id)}"
+    form_parts << "pages[]=#{CGI.escape('1-last')}"
+    form_parts << "type[]=id"
+  end
+
+  resp_merge = conn.post("/merged-pdf") do |req|
+    req.headers["api-key"] = API_KEY
+    req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+    req.body = form_parts.join('&')
+  end
+
+  puts resp_merge.body
+  abort("Merge failed with status #{resp_merge.status}") unless resp_merge.success?
+
+rescue KeyError => e
+  abort("Unexpected response format: #{e.message}")
+rescue => e
+  abort("Error: #{e.class}: #{e.message}")
+end

--- a/Ruby/Complex Flow Examples/merge-different-file-types.rb
+++ b/Ruby/Complex Flow Examples/merge-different-file-types.rb
@@ -8,6 +8,7 @@
 # - Set PDFREST_API_KEY=your_api_key_here
 # - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
 #     PDFREST_URL=https://eu-api.pdfrest.com
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
 #
 # Usage:
 #   ruby "Complex Flow Examples/merge-different-file-types.rb" /path/to/file1 /path/to/file2 [...]

--- a/Ruby/Complex Flow Examples/merge-different-file-types.rb
+++ b/Ruby/Complex Flow Examples/merge-different-file-types.rb
@@ -1,23 +1,27 @@
+#!
+# What this sample does:
+# - Merges multiple inputs (PDFs and non-PDFs) into a single PDF.
+# - Non-PDF files are first converted to PDF; PDFs are uploaded as-is. All resulting IDs are then merged.
+#
+# Setup (.env):
+# - Copy .env.example to .env
+# - Set PDFREST_API_KEY=your_api_key_here
+# - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+#     PDFREST_URL=https://eu-api.pdfrest.com
+#
+# Usage:
+#   ruby "Complex Flow Examples/merge-different-file-types.rb" /path/to/file1 /path/to/file2 [...]
+#
+# Output:
+# - Prints the API JSON response to stdout. Non-2xx responses abort with a concise message.
+# - Tip: pipe output to a file: ruby ... > response.json
+
 require "json"
 require "faraday"
 require "faraday/retry"
 require "faraday/multipart"
 require "dotenv"
 require "cgi"
-
-# In this sample, we demonstrate how to merge different file types together,
-# inspired by the PHP example at ../PHP/Complex Flow Examples/merge-different-file-types.php
-# and the solution described at https://pdfrest.com/solutions/merge-multiple-types-of-files-together/.
-#
-# Flow:
-# 1) For each input path provided on the command line:
-#    - If the input is NOT a PDF, convert it to PDF via the /pdf endpoint and capture its outputId.
-#    - If the input IS a PDF, do not reconvert; upload it to /upload and capture the returned file id.
-# 2) Pass all collected IDs to /merged-pdf with matching pages[]=1-last and type[]=id entries.
-#
-# Notes:
-# - Set PDFREST_API_KEY in .env (dotenv loads it). Optionally set PDFREST_URL to override the base URL
-#   (defaults to https://api.pdfrest.com). See README for EU/GDPR endpoint details.
 
 Dotenv.load
 

--- a/Ruby/Endpoint Examples/JSON Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/markdown.rb
@@ -8,6 +8,9 @@ Dotenv.load
 API_KEY = ENV["PDFREST_API_KEY"]
 abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
 
+# Allow overriding the API base URL via .env (default to US endpoint)
+API_BASE = (ENV["PDFREST_URL"] || ENV["PDFREST_API"] || "https://api.pdfrest.com").sub(%r{/+$}, "")
+
 pdf_path = ARGV[0]
 abort("Usage: ruby markdown.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
 
@@ -16,7 +19,7 @@ file_bytes = File.binread(pdf_path)
 
 begin
   # 1) Upload the file
-  upload_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+  upload_conn = Faraday.new(url: API_BASE) do |f|
     f.request :retry, max: 2, interval: 0.2
     f.adapter Faraday.default_adapter
   end
@@ -38,7 +41,7 @@ begin
   STDERR.puts "Successfully uploaded with an id of: #{uploaded_id}"
 
   # 2) Convert to Markdown
-  markdown_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+  markdown_conn = Faraday.new(url: API_BASE) do |f|
     f.request :retry, max: 2, interval: 0.2
     f.adapter Faraday.default_adapter
   end

--- a/Ruby/Endpoint Examples/JSON Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/markdown.rb
@@ -1,0 +1,63 @@
+require "json"
+require "faraday"
+require "faraday/retry"
+require "dotenv"
+
+Dotenv.load
+
+API_KEY = ENV["PDFREST_API_KEY"]
+abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
+
+pdf_path = ARGV[0]
+abort("Usage: ruby markdown.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
+
+filename = File.basename(pdf_path)
+file_bytes = File.binread(pdf_path)
+
+begin
+  # 1) Upload the file
+  upload_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+    f.request :retry, max: 2, interval: 0.2
+    f.adapter Faraday.default_adapter
+  end
+
+  upload_resp = upload_conn.post("/upload") do |req|
+    req.headers["api-key"] = API_KEY
+    req.headers["content-filename"] = filename
+    req.headers["Content-Type"] = "application/octet-stream"
+    req.body = file_bytes
+  end
+
+  STDERR.puts upload_resp.body
+  unless upload_resp.success?
+    abort("Upload failed with status #{upload_resp.status}")
+  end
+
+  upload_json = JSON.parse(upload_resp.body)
+  uploaded_id = upload_json.fetch("files").fetch(0).fetch("id")
+  STDERR.puts "Successfully uploaded with an id of: #{uploaded_id}"
+
+  # 2) Convert to Markdown
+  markdown_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+    f.request :retry, max: 2, interval: 0.2
+    f.adapter Faraday.default_adapter
+  end
+
+  body = { id: uploaded_id, page_break_comments: "on" }.to_json
+
+  markdown_resp = markdown_conn.post("/markdown") do |req|
+    req.headers["api-key"] = API_KEY
+    req.headers["Content-Type"] = "application/json"
+    req.body = body
+  end
+
+  puts markdown_resp.body
+  unless markdown_resp.success?
+    abort("Markdown conversion failed with status #{markdown_resp.status}")
+  end
+
+rescue KeyError => e
+  abort("Unexpected response format: #{e.message}")
+rescue => e
+  abort("Error: #{e.class}: #{e.message}")
+end

--- a/Ruby/Endpoint Examples/JSON Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/markdown.rb
@@ -1,3 +1,21 @@
+#!
+# What this sample does:
+# - Converts a PDF to Markdown using pdfRest.
+# - Uses a JSON payload in two steps: first uploads, then calls /markdown with the uploaded id.
+#
+# Setup (.env):
+# - Copy .env.example to .env
+# - Set PDFREST_API_KEY=your_api_key_here
+# - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+#     PDFREST_URL=https://eu-api.pdfrest.com
+#
+# Usage:
+#   ruby "Endpoint Examples/JSON Payload/markdown.rb" /path/to/input.pdf
+#
+# Output:
+# - Prints the API JSON response to stdout. Non-2xx responses abort with a concise message.
+# - Tip: pipe output to a file: ruby ... > response.json
+
 require "json"
 require "faraday"
 require "faraday/retry"

--- a/Ruby/Endpoint Examples/JSON Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/markdown.rb
@@ -8,6 +8,7 @@
 # - Set PDFREST_API_KEY=your_api_key_here
 # - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
 #     PDFREST_URL=https://eu-api.pdfrest.com
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
 #
 # Usage:
 #   ruby "Endpoint Examples/JSON Payload/markdown.rb" /path/to/input.pdf

--- a/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
@@ -1,3 +1,21 @@
+#!
+# What this sample does:
+# - Creates a rasterized version of a PDF using pdfRest.
+# - Uses a JSON payload in two steps: first uploads, then calls /rasterized-pdf with the uploaded id.
+#
+# Setup (.env):
+# - Copy .env.example to .env
+# - Set PDFREST_API_KEY=your_api_key_here
+# - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+#     PDFREST_URL=https://eu-api.pdfrest.com
+#
+# Usage:
+#   ruby "Endpoint Examples/JSON Payload/rasterized-pdf.rb" /path/to/input.pdf
+#
+# Output:
+# - Prints the API JSON response to stdout. Non-2xx responses abort with a concise message.
+# - Tip: pipe output to a file: ruby ... > response.json
+
 require "json"
 require "faraday"
 require "faraday/retry"

--- a/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
@@ -1,0 +1,65 @@
+require "json"
+require "faraday"
+require "faraday/retry"
+require "dotenv"
+
+Dotenv.load
+
+API_KEY = ENV["PDFREST_API_KEY"]
+abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
+
+pdf_path = ARGV[0]
+abort("Usage: ruby rasterized_pdf.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
+
+filename = File.basename(pdf_path)
+file_bytes = File.binread(pdf_path)
+
+begin
+  # 1) Upload the file
+  upload_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+    f.request :retry, max: 2, interval: 0.2
+    f.adapter Faraday.default_adapter
+  end
+
+  upload_resp = upload_conn.post("/upload") do |req|
+    req.headers["api-key"] = API_KEY
+    req.headers["content-filename"] = filename
+    req.headers["Content-Type"] = "application/octet-stream"
+    req.body = file_bytes
+  end
+
+  STDERR.puts upload_resp.body
+  unless upload_resp.success?
+    abort("Upload failed with status #{upload_resp.status}")
+  end
+
+  upload_json = JSON.parse(upload_resp.body)
+  uploaded_id = upload_json.fetch("files").fetch(0).fetch("id")
+  STDERR.puts "Successfully uploaded with an id of: #{uploaded_id}"
+
+  # 2) Create rasterized PDF
+  raster_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+    f.request :retry, max: 2, interval: 0.2
+    f.adapter Faraday.default_adapter
+  end
+
+  # Provide only the required parameter (id). Add optional params as needed.
+  # Example optional params you might add later: dpi, color_space, page_range, etc.
+  body = { id: uploaded_id }.to_json
+
+  raster_resp = raster_conn.post("/rasterized-pdf") do |req|
+    req.headers["api-key"] = API_KEY
+    req.headers["Content-Type"] = "application/json"
+    req.body = body
+  end
+
+  puts raster_resp.body
+  unless raster_resp.success?
+    abort("Rasterization failed with status #{raster_resp.status}")
+  end
+
+rescue KeyError => e
+  abort("Unexpected response format: #{e.message}")
+rescue => e
+  abort("Error: #{e.class}: #{e.message}")
+end

--- a/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
@@ -8,6 +8,7 @@
 # - Set PDFREST_API_KEY=your_api_key_here
 # - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
 #     PDFREST_URL=https://eu-api.pdfrest.com
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
 #
 # Usage:
 #   ruby "Endpoint Examples/JSON Payload/rasterized-pdf.rb" /path/to/input.pdf

--- a/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/JSON Payload/rasterized-pdf.rb
@@ -8,6 +8,9 @@ Dotenv.load
 API_KEY = ENV["PDFREST_API_KEY"]
 abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
 
+# Allow overriding the API base URL via .env (default to US endpoint)
+API_BASE = (ENV["PDFREST_URL"] || ENV["PDFREST_API"] || "https://api.pdfrest.com").sub(%r{/+$}, "")
+
 pdf_path = ARGV[0]
 abort("Usage: ruby rasterized_pdf.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
 
@@ -16,7 +19,7 @@ file_bytes = File.binread(pdf_path)
 
 begin
   # 1) Upload the file
-  upload_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+  upload_conn = Faraday.new(url: API_BASE) do |f|
     f.request :retry, max: 2, interval: 0.2
     f.adapter Faraday.default_adapter
   end
@@ -38,7 +41,7 @@ begin
   STDERR.puts "Successfully uploaded with an id of: #{uploaded_id}"
 
   # 2) Create rasterized PDF
-  raster_conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+  raster_conn = Faraday.new(url: API_BASE) do |f|
     f.request :retry, max: 2, interval: 0.2
     f.adapter Faraday.default_adapter
   end

--- a/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
@@ -8,6 +8,7 @@
 # - Set PDFREST_API_KEY=your_api_key_here
 # - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
 #     PDFREST_URL=https://eu-api.pdfrest.com
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
 #
 # Usage:
 #   ruby "Endpoint Examples/Multipart Payload/markdown.rb" /path/to/input.pdf

--- a/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
@@ -9,13 +9,16 @@ Dotenv.load
 API_KEY = ENV["PDFREST_API_KEY"]
 abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
 
+# Allow overriding the API base URL via .env (default to US endpoint)
+API_BASE = (ENV["PDFREST_URL"] || ENV["PDFREST_API"] || "https://api.pdfrest.com").sub(%r{/+$}, "")
+
 pdf_path = ARGV[0]
 abort("Usage: ruby markdown_multipart.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
 
 filename = File.basename(pdf_path)
 
 begin
-  conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+  conn = Faraday.new(url: API_BASE) do |f|
     f.request :retry, max: 2, interval: 0.2
     f.request :multipart
     f.adapter Faraday.default_adapter

--- a/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
@@ -1,0 +1,45 @@
+# ruby
+require "faraday"
+require "faraday/retry"
+require "faraday/multipart"
+require "dotenv"
+
+Dotenv.load
+
+API_KEY = ENV["PDFREST_API_KEY"]
+abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
+
+pdf_path = ARGV[0]
+abort("Usage: ruby markdown_multipart.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
+
+filename = File.basename(pdf_path)
+
+begin
+  conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+    f.request :retry, max: 2, interval: 0.2
+    f.request :multipart
+    f.adapter Faraday.default_adapter
+  end
+
+  # Build multipart form body. Middleware will set multipart/form-data with boundary.
+  body = {
+    file: Faraday::Multipart::FilePart.new(pdf_path, "application/pdf", filename),
+    output: "pdfrest_markdown",
+    page_break_comments: "on",
+    # Optional parameters:
+    # page_range: "1-3"
+  }
+
+  resp = conn.post("/markdown") do |req|
+    req.headers["api-key"] = API_KEY
+    req.body = body
+  end
+
+  puts resp.body
+  unless resp.success?
+    abort("Markdown conversion failed with status #{resp.status}")
+  end
+
+rescue => e
+  abort("Error: #{e.class}: #{e.message}")
+end

--- a/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/markdown.rb
@@ -1,3 +1,21 @@
+#!
+# What this sample does:
+# - Converts a PDF to Markdown using pdfRest.
+# - Sends a single multipart/form-data request directly to /markdown with the file.
+#
+# Setup (.env):
+# - Copy .env.example to .env
+# - Set PDFREST_API_KEY=your_api_key_here
+# - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+#     PDFREST_URL=https://eu-api.pdfrest.com
+#
+# Usage:
+#   ruby "Endpoint Examples/Multipart Payload/markdown.rb" /path/to/input.pdf
+#
+# Output:
+# - Prints the API JSON response to stdout. Non-2xx responses abort with a concise message.
+# - Tip: pipe output to a file: ruby ... > response.json
+
 # ruby
 require "faraday"
 require "faraday/retry"

--- a/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
@@ -8,13 +8,16 @@ Dotenv.load
 API_KEY = ENV["PDFREST_API_KEY"]
 abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
 
+# Allow overriding the API base URL via .env (default to US endpoint)
+API_BASE = (ENV["PDFREST_URL"] || ENV["PDFREST_API"] || "https://api.pdfrest.com").sub(%r{/+$}, "")
+
 pdf_path = ARGV[0]
 abort("Usage: ruby rasterized_pdf_multipart.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
 
 filename = File.basename(pdf_path)
 
 begin
-  conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+  conn = Faraday.new(url: API_BASE) do |f|
     f.request :retry, max: 2, interval: 0.2
     f.request :multipart
     f.adapter Faraday.default_adapter

--- a/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
@@ -1,0 +1,45 @@
+require "faraday"
+require "faraday/retry"
+require "dotenv"
+require "faraday/multipart"
+
+Dotenv.load
+
+API_KEY = ENV["PDFREST_API_KEY"]
+abort("Missing PDFREST_API_KEY in .env") if API_KEY.nil? || API_KEY.strip.empty?
+
+pdf_path = ARGV[0]
+abort("Usage: ruby rasterized_pdf_multipart.rb /path/to/file.pdf") unless pdf_path && File.file?(pdf_path)
+
+filename = File.basename(pdf_path)
+
+begin
+  conn = Faraday.new(url: "https://api.pdfrest.com") do |f|
+    f.request :retry, max: 2, interval: 0.2
+    f.request :multipart
+    f.adapter Faraday.default_adapter
+  end
+
+  # Build multipart form body. Faraday will set the proper multipart/form-data boundary.
+  body = {
+    file: Faraday::Multipart::FilePart.new(pdf_path, "application/pdf", filename),
+    output: "pdfrest_rasterize"
+    # Optional parameters you can include:
+    # dpi: "300",
+    # color_space: "rgb",
+    # page_range: "1-3"
+  }
+
+  resp = conn.post("/rasterized-pdf") do |req|
+    req.headers["api-key"] = API_KEY
+    req.body = body
+  end
+
+  puts resp.body
+  unless resp.success?
+    abort("Rasterization failed with status #{resp.status}")
+  end
+
+rescue => e
+  abort("Error: #{e.class}: #{e.message}")
+end

--- a/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
@@ -1,3 +1,21 @@
+#!
+# What this sample does:
+# - Creates a rasterized version of a PDF using pdfRest.
+# - Sends a single multipart/form-data request directly to /rasterized-pdf with the file.
+#
+# Setup (.env):
+# - Copy .env.example to .env
+# - Set PDFREST_API_KEY=your_api_key_here
+# - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+#     PDFREST_URL=https://eu-api.pdfrest.com
+#
+# Usage:
+#   ruby "Endpoint Examples/Multipart Payload/rasterized-pdf.rb" /path/to/input.pdf
+#
+# Output:
+# - Prints the API JSON response to stdout. Non-2xx responses abort with a concise message.
+# - Tip: pipe output to a file: ruby ... > response.json
+
 require "faraday"
 require "faraday/retry"
 require "dotenv"

--- a/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
+++ b/Ruby/Endpoint Examples/Multipart Payload/rasterized-pdf.rb
@@ -8,6 +8,7 @@
 # - Set PDFREST_API_KEY=your_api_key_here
 # - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
 #     PDFREST_URL=https://eu-api.pdfrest.com
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
 #
 # Usage:
 #   ruby "Endpoint Examples/Multipart Payload/rasterized-pdf.rb" /path/to/input.pdf

--- a/Ruby/Gemfile
+++ b/Ruby/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "faraday", "~> 2.10"
+gem "dotenv", "~> 3.1"
+gem "faraday-retry", "~> 2.2"
+
+gem "faraday-multipart", "~> 1.1"

--- a/Ruby/Gemfile.lock
+++ b/Ruby/Gemfile.lock
@@ -1,0 +1,33 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    dotenv (3.1.8)
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
+    json (2.13.2)
+    logger (1.7.0)
+    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
+    uri (1.0.3)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  dotenv (~> 3.1)
+  faraday (~> 2.10)
+  faraday-multipart (~> 1.1)
+  faraday-retry (~> 2.2)
+
+BUNDLED WITH
+   2.7.1

--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -123,6 +123,16 @@ Notes:
     - Responses are printed to stdout (typically JSON). You may pipe or redirect to files:
         - ruby "<path to sample>.rb" input.pdf > response.json
 
+### EU/GDPR Endpoint (Optional)
+
+- Base URL
+    - By default, samples call `https://api.pdfrest.com`.
+    - For GDPR compliance and improved performance for European users, set in `.env`:
+        - `PDFREST_URL=https://eu-api.pdfrest.com/`
+    - If `PDFREST_URL` is not set, the default US endpoint is used.
+- More information
+    - Learn how EU GDPR API calls work: https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+
 ---
 
 ## Troubleshooting

--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -58,6 +58,8 @@ Each script prints the API response to stdout and exits non-zero on errors.
         - <endpoint>.rb
     - Multipart Payload/
         - <endpoint>.rb
+- Complex Flow Examples/
+    - Higher-level workflows that chain multiple endpoints, e.g., converting mixed input types and merging results.
 
 You can:
 
@@ -106,6 +108,12 @@ From the repository root:
     - ruby "Endpoint Examples/Multipart Payload/markdown.rb" /path/to/input.pdf
     - ruby "Endpoint Examples/Multipart Payload/rasterized-pdf.rb" /path/to/input.pdf
 
+- Complex Flow examples:
+    - ruby "Complex Flow Examples/merge-different-file-types.rb" /path/to/file1 /path/to/file2 [/path/to/file3 ...]
+      - Accepts 2+ files of mixed types (e.g., PNG, PPTX, PDF).
+      - Non-PDFs are converted to PDF via `/pdf`; PDFs are uploaded via `/upload`.
+      - All resulting IDs are then merged via `/merged-pdf`.
+
 Notes:
 - Replace /path/to/input.pdf with your local file path.
 - Some samples may accept or document optional parameters (e.g., page ranges, DPI, color space). Review the sample file and inline comments to see what options are available for that endpoint type.
@@ -132,6 +140,21 @@ Notes:
     - If `PDFREST_URL` is not set, the default US endpoint is used.
 - More information
     - Learn how EU GDPR API calls work: https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+
+---
+
+## Complex Flow Examples
+
+Complex flows demonstrate multi-step workflows that combine endpoints to solve real tasks. For example, `merge-different-file-types.rb` will:
+- Convert all non-PDF inputs to PDF using `/pdf`.
+- Upload any PDF inputs using `/upload` (no reconversion).
+- Merge all collected IDs into one document via `/merged-pdf`.
+
+Usage:
+- ruby "Complex Flow Examples/merge-different-file-types.rb" file1.png file2.pptx file3.pdf
+
+Notes:
+- Requires `PDFREST_API_KEY` in `.env`; honors `PDFREST_URL` (defaults to `https://api.pdfrest.com`).
 
 ---
 

--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -1,0 +1,152 @@
+# pdfRest Ruby Samples
+
+A growing collection of Ruby scripts that demonstrate how to call the pdfRest API from the command line. These samples are organized by the type of HTTP payload they send to the API and will expand over time to cover many endpoints and options.
+
+Current samples illustrate two request styles:
+- JSON Payload samples
+- Multipart Payload samples
+
+Use this README from the repository’s top-level directory.
+
+---
+
+## Prerequisites
+
+- Ruby 3.4.4 (via rbenv recommended)
+- Bundler 2.7.1
+- A pdfRest API key
+- macOS/Linux/WSL or any environment where Ruby and Bundler are available
+
+Project gems:
+- dotenv
+- faraday
+- faraday-multipart
+- faraday-retry
+
+---
+
+## Quick Start
+
+1) Install Ruby (recommended via rbenv)
+- Install rbenv per your OS instructions.
+- Install and select the required Ruby version:
+    - rbenv install 3.4.4
+    - rbenv local 3.4.4
+
+2) Install dependencies
+- bundle install
+
+3) Configure your API key
+- Copy .env.example to .env
+- Set PDFREST_API_KEY in .env:
+    - PDFREST_API_KEY=your_api_key_here
+
+4) Run a sample (from the repo root)
+- JSON payload example:
+    - ruby "Endpoint Examples/JSON Payload/markdown.rb" /path/to/input.pdf
+- Multipart payload example:
+    - ruby "Endpoint Examples/Multipart Payload/markdown.rb" /path/to/input.pdf
+
+Each script prints the API response to stdout and exits non-zero on errors.
+
+---
+
+## Project Structure
+
+- Endpoint Examples/
+    - JSON Payload/
+        - <endpoint>.rb
+    - Multipart Payload/
+        - <endpoint>.rb
+
+You can:
+
+- Browse the folders above to find the endpoint you want.
+- Use the Ruby script name as a hint for the pdfRest API operation it demonstrates.
+- Run the script with the path to your input file as the first argument, unless noted otherwise.
+
+---
+
+## JSON vs Multipart: What’s the Difference?
+
+Both styles ultimately call the same API endpoints and return JSON responses, but they differ in how they send files and parameters.
+
+1) JSON Payload Samples
+- Flow:
+    - Upload the file first to receive a file id.
+    - Call the target endpoint with a JSON body that includes the file id and any options.
+- Characteristics:
+    - Content-Type: application/json
+    - Useful when you want to reuse the same uploaded file across multiple operations without re-uploading.
+    - Slightly more steps (upload + operation) but efficient for pipelines or repeated operations.
+
+2) Multipart Payload Samples
+- Flow:
+    - Send the file and options in a single multipart/form-data request directly to the endpoint.
+- Characteristics:
+    - Content-Type: multipart/form-data
+    - Simpler for one-off operations (no separate upload step).
+    - Re-uploads the file each time you call an endpoint.
+
+When to choose which:
+- Choose JSON Payload if you plan to chain operations or reuse files.
+- Choose Multipart Payload for quick, single-shot conversions per file.
+
+---
+
+## Running the Samples
+
+From the repository root:
+
+- JSON Payload samples:
+    - ruby "Endpoint Examples/JSON Payload/markdown.rb" /path/to/input.pdf
+    - ruby "Endpoint Examples/JSON Payload/rasterized-pdf.rb" /path/to/input.pdf
+
+- Multipart Payload samples:
+    - ruby "Endpoint Examples/Multipart Payload/markdown.rb" /path/to/input.pdf
+    - ruby "Endpoint Examples/Multipart Payload/rasterized-pdf.rb" /path/to/input.pdf
+
+Notes:
+- Replace /path/to/input.pdf with your local file path.
+- Some samples may accept or document optional parameters (e.g., page ranges, DPI, color space). Review the sample file and inline comments to see what options are available for that endpoint type.
+- All scripts require PDFREST_API_KEY in your environment via .env.
+
+---
+
+## Environment and Configuration
+
+- API key
+    - Set PDFREST_API_KEY in .env (dotenv loads this automatically).
+- Retries
+    - Samples are configured with brief, limited retries for transient network errors.
+- Output
+    - Responses are printed to stdout (typically JSON). You may pipe or redirect to files:
+        - ruby "<path to sample>.rb" input.pdf > response.json
+
+---
+
+## Troubleshooting
+
+- “Missing PDFREST_API_KEY in .env”
+    - Ensure .env exists at the top level and includes a valid PDFREST_API_KEY.
+- “Usage: … /path/to/file.pdf”
+    - Pass a valid file path as the first argument.
+- HTTP error responses
+    - Non-2xx responses will cause the script to exit with a message and non-zero status. Inspect the printed response for details.
+- Network/Proxy issues
+    - If behind a corporate proxy, configure standard environment variables (e.g., HTTPS_PROXY) before running the scripts.
+
+---
+
+## Developing and Contributing
+
+- Update dependencies
+    - bundle update
+- Ruby version
+    - rbenv local 3.4.4 (if not already set)
+- Adding new samples
+    - Place new scripts under:
+        - Endpoint Examples/JSON Payload/ for two-step (upload + JSON) examples
+        - Endpoint Examples/Multipart Payload/ for single-step multipart examples
+    - Keep naming consistent with the target endpoint for easy discovery.
+    - Follow the pattern of reading configuration from .env and accepting the input file path as the first argument.


### PR DESCRIPTION
- Add JSON and Multipart payload examples demonstrating API usage.
- Include `.env.example` and integrate `dotenv` for API key management.
- Add `.gitignore` tailored for Ruby projects.
- Introduce `Gemfile` and `Gemfile.lock` for dependency management.
- Provide comprehensive documentation in `README.md`.