### PR TITLE
PDFCLOUD-5217 Runnable C# samples

### DIFF
--- a/DotNET/.env.example
+++ b/DotNET/.env.example
@@ -8,3 +8,9 @@ PDFREST_API_KEY=your_api_key_here
 # - EU/GDPR region: https://eu-api.pdfrest.com
 PDFREST_URL=https://api.pdfrest.com
 # For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+
+# Optional: Immediate deletion of sensitive files
+# - Default behavior: files are retained per the File Retention Period.
+# - Set to true to immediately delete uploaded/generated files in samples that support it.
+#   Valid values: true|false (case-insensitive)
+PDFREST_DELETE_SENSITIVE_FILES=false

--- a/DotNET/Complex Flow Examples/ocr-with-extract-text.cs
+++ b/DotNET/Complex Flow Examples/ocr-with-extract-text.cs
@@ -64,7 +64,7 @@ namespace Samples.ComplexFlowExamples
                 Console.WriteLine("OCR response received.");
                 Console.WriteLine(ocrResult);
                 var ocrJson = JObject.Parse(ocrResult);
-                var ocrPDFID = (string?) (ocrJson["outputId"] ?? ocrJson["id"] ?? ocrJson["files"]?[0]? ["id"]);
+                var ocrPDFID = (string?)(ocrJson["outputId"] ?? ocrJson["id"] ?? ocrJson["files"]?[0]?["id"]);
                 if (string.IsNullOrWhiteSpace(ocrPDFID))
                 {
                     Console.Error.WriteLine("Failed to obtain OCR output id. Full response:");

--- a/DotNET/Endpoint Examples/JSON Payload/decrypted-pdf.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/decrypted-pdf.cs
@@ -100,7 +100,7 @@ namespace Samples.EndpointExamples.JsonPayload
                         // is involved, an explicit delete call can be made to the API.
                         //
                         // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
-                        
+
                         // Optional immediate deletion of sensitive files
                         // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
                         var deleteSensitiveFiles = string.Equals(

--- a/DotNET/Endpoint Examples/JSON Payload/decrypted-pdf.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/decrypted-pdf.cs
@@ -101,8 +101,12 @@ namespace Samples.EndpointExamples.JsonPayload
                         //
                         // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
                         
-                        // Toggle deletion of sensitive files (default: false)
-                        var deleteSensitiveFiles = false;
+                        // Optional immediate deletion of sensitive files
+                        // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                        var deleteSensitiveFiles = string.Equals(
+                            Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                            "true",
+                            StringComparison.OrdinalIgnoreCase);
 
                         if (deleteSensitiveFiles)
                         {

--- a/DotNET/Endpoint Examples/JSON Payload/delete.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/delete.cs
@@ -10,7 +10,7 @@
  *   For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
  *
  * Usage:
- *   dotnet run -- batch-delete <id1> [id2] [...]
+ *   dotnet run -- delete <id1> [id2] [...]
  *
  * Output:
  * - Prints JSON responses; non-2xx results exit non-zero.
@@ -20,13 +20,13 @@ using System.Text;
 
 namespace Samples.EndpointExamples.JsonPayload
 {
-    public static class BatchDelete
+    public static class Delete
     {
         public static async Task Execute(string[] args)
         {
             if (args == null || args.Length < 1)
             {
-                Console.Error.WriteLine("batch-delete requires <id1> [id2] [id3] ... OR a single comma-separated list");
+                Console.Error.WriteLine("delete requires <id1> [id2] [id3] ... OR a single comma-separated list");
                 Environment.Exit(1);
                 return;
             }

--- a/DotNET/Endpoint Examples/JSON Payload/encrypted-pdf.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/encrypted-pdf.cs
@@ -103,8 +103,12 @@ namespace Samples.EndpointExamples.JsonPayload
                         //
                         // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                        // Toggle deletion of sensitive files (default: false)
-                        var deleteSensitiveFiles = false;
+                        // Optional immediate deletion of sensitive files
+                        // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                        var deleteSensitiveFiles = string.Equals(
+                            Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                            "true",
+                            StringComparison.OrdinalIgnoreCase);
 
                         if (deleteSensitiveFiles)
                         {

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-with-redacted-text-applied.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-with-redacted-text-applied.cs
@@ -56,7 +56,7 @@ namespace Samples.EndpointExamples.JsonPayload
                     var redactedTextResult = await redactedTextResponse.Content.ReadAsStringAsync();
                     Console.WriteLine("Processing response received.");
                     Console.WriteLine(redactedTextResult);
-                    
+
                     JObject appliedResultJson = JObject.Parse(redactedTextResult);
                     var outputID = appliedResultJson["outputId"];
 

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-with-redacted-text-applied.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-with-redacted-text-applied.cs
@@ -67,8 +67,12 @@ namespace Samples.EndpointExamples.JsonPayload
                     //
                     // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                    // Toggle deletion of sensitive files (default: false)
-                    var deleteSensitiveFiles = false;
+                    // Optional immediate deletion of sensitive files
+                    // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                    var deleteSensitiveFiles = string.Equals(
+                        Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                        "true",
+                        StringComparison.OrdinalIgnoreCase);
 
                     if (deleteSensitiveFiles)
                     {

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-with-redacted-text-preview.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-with-redacted-text-preview.cs
@@ -72,8 +72,12 @@ namespace Samples.EndpointExamples.JsonPayload
                     // IMPORTANT: Do not delete the previewId (the preview PDF) file until after the redaction is applied
                     // with the /pdf-with-redacted-text-applied endpoint.
 
-                    // Toggle deletion of sensitive files (default: false)
-                    var deleteSensitiveFiles = false;
+                    // Optional immediate deletion of sensitive files
+                    // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                    var deleteSensitiveFiles = string.Equals(
+                        Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                        "true",
+                        StringComparison.OrdinalIgnoreCase);
 
                     if (deleteSensitiveFiles)
                     {

--- a/DotNET/Endpoint Examples/JSON Payload/restricted-pdf.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/restricted-pdf.cs
@@ -104,8 +104,12 @@ namespace Samples.EndpointExamples.JsonPayload
                         //
                         // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                        // Toggle deletion of sensitive files (default: false)
-                        var deleteSensitiveFiles = false;
+                        // Optional immediate deletion of sensitive files
+                        // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                        var deleteSensitiveFiles = string.Equals(
+                            Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                            "true",
+                            StringComparison.OrdinalIgnoreCase);
 
                         if (deleteSensitiveFiles)
                         {

--- a/DotNET/Endpoint Examples/JSON Payload/unrestricted-pdf.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/unrestricted-pdf.cs
@@ -101,8 +101,12 @@ namespace Samples.EndpointExamples.JsonPayload
                         //
                         // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                        // Toggle deletion of sensitive files (default: false)
-                        var deleteSensitiveFiles = false;
+                        // Optional immediate deletion of sensitive files
+                        // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                        var deleteSensitiveFiles = string.Equals(
+                            Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                            "true",
+                            StringComparison.OrdinalIgnoreCase);
 
                         if (deleteSensitiveFiles)
                         {

--- a/DotNET/Endpoint Examples/JSON Payload/watermarked-pdf.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/watermarked-pdf.cs
@@ -66,8 +66,12 @@ namespace Samples.EndpointExamples.JsonPayload
                     //
                     // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                    // Toggle deletion of sensitive files (default: false)
-                    var deleteSensitiveFiles = false;
+                    // Optional immediate deletion of sensitive files
+                    // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                    var deleteSensitiveFiles = string.Equals(
+                        Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                        "true",
+                        StringComparison.OrdinalIgnoreCase);
 
                     if (deleteSensitiveFiles)
                     {

--- a/DotNET/Endpoint Examples/Multipart Payload/decrypted-pdf.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/decrypted-pdf.cs
@@ -79,8 +79,12 @@ namespace Samples.EndpointExamples.MultipartPayload
                 //
                 // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                // Toggle deletion of sensitive files (default: false)
-                var deleteSensitiveFiles = false;
+                // Optional immediate deletion of sensitive files
+                // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                var deleteSensitiveFiles = string.Equals(
+                    Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
 
                 if (deleteSensitiveFiles)
                 {

--- a/DotNET/Endpoint Examples/Multipart Payload/delete.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/delete.cs
@@ -1,7 +1,7 @@
 /*
  * What this sample does:
  * - Deletes multiple resources by ids.
- * - Routed from Program.cs as: `dotnet run -- batch-delete-multipart <id1> [id2] [...]`.
+ * - Routed from Program.cs as: `dotnet run -- delete-multipart <id1> [id2] [...]`.
  *
  * Setup (environment):
  * - Copy .env.example to .env
@@ -11,7 +11,7 @@
  *   For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
  *
  * Usage:
- *   dotnet run -- batch-delete-multipart id1 id2 id3
+ *   dotnet run -- delete-multipart id1 id2 id3
  *
  * Output:
  * - Prints the JSON response. Validation errors (args/env) exit non-zero.
@@ -19,13 +19,13 @@
 
 namespace Samples.EndpointExamples.MultipartPayload
 {
-    public static class BatchDelete
+    public static class Delete
     {
         public static async Task Execute(string[] args)
         {
             if (args == null || args.Length < 1)
             {
-                Console.Error.WriteLine("batch-delete-multipart requires <id1> [id2] [...]");
+                Console.Error.WriteLine("delete-multipart requires <id1> [id2] [...]");
                 Environment.Exit(1);
                 return;
             }

--- a/DotNET/Endpoint Examples/Multipart Payload/encrypted-pdf.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/encrypted-pdf.cs
@@ -79,8 +79,12 @@ namespace Samples.EndpointExamples.MultipartPayload
                 //
                 // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                // Toggle deletion of sensitive files (default: false)
-                var deleteSensitiveFiles = false;
+                // Optional immediate deletion of sensitive files
+                // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                var deleteSensitiveFiles = string.Equals(
+                    Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
 
                 if (deleteSensitiveFiles)
                 {

--- a/DotNET/Endpoint Examples/Multipart Payload/get-resource.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/get-resource.cs
@@ -33,14 +33,6 @@ namespace Samples.EndpointExamples.MultipartPayload
             var id = args[0];
             var outPath = args.Length > 1 ? args[1] : "resource.bin";
 
-            var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
-            if (string.IsNullOrWhiteSpace(apiKey))
-            {
-                Console.Error.WriteLine("Missing required environment variable: PDFREST_API_KEY");
-                Environment.Exit(1);
-                return;
-            }
-
             var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
             var resourceBase = baseUrl.TrimEnd('/') + "/resource/";
 
@@ -50,7 +42,6 @@ namespace Samples.EndpointExamples.MultipartPayload
                 {
                     using (var request = new HttpRequestMessage(HttpMethod.Get, id + "?format=file"))
                     {
-                        request.Headers.TryAddWithoutValidation("Api-Key", apiKey);
                         using (var response = await httpClient.SendAsync(request))
                         {
                             response.EnsureSuccessStatusCode();

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-with-redacted-text-applied.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-with-redacted-text-applied.cs
@@ -76,8 +76,12 @@ namespace Samples.EndpointExamples.MultipartPayload
                 //
                 // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                // Toggle deletion of sensitive files (default: false)
-                var deleteSensitiveFiles = false;
+                // Optional immediate deletion of sensitive files
+                // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                var deleteSensitiveFiles = string.Equals(
+                    Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
 
                 if (deleteSensitiveFiles)
                 {

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-with-redacted-text-preview.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-with-redacted-text-preview.cs
@@ -93,8 +93,12 @@ namespace Samples.EndpointExamples.MultipartPayload
                 //
                 // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                // Toggle deletion of sensitive files (default: false)
-                var deleteSensitiveFiles = false;
+                // Optional immediate deletion of sensitive files
+                // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                var deleteSensitiveFiles = string.Equals(
+                    Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
 
                 if (deleteSensitiveFiles)
                 {

--- a/DotNET/Endpoint Examples/Multipart Payload/restricted-pdf.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/restricted-pdf.cs
@@ -82,8 +82,12 @@ namespace Samples.EndpointExamples.MultipartPayload
                 //
                 // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                // Toggle deletion of sensitive files (default: false)
-                var deleteSensitiveFiles = false;
+                // Optional immediate deletion of sensitive files
+                // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                var deleteSensitiveFiles = string.Equals(
+                    Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
 
                 if (deleteSensitiveFiles)
                 {

--- a/DotNET/Endpoint Examples/Multipart Payload/unrestricted-pdf.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/unrestricted-pdf.cs
@@ -78,8 +78,12 @@ namespace Samples.EndpointExamples.MultipartPayload
                 //
                 // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                // Toggle deletion of sensitive files (default: false)
-                var deleteSensitiveFiles = false;
+                // Optional immediate deletion of sensitive files
+                // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                var deleteSensitiveFiles = string.Equals(
+                    Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
 
                 if (deleteSensitiveFiles)
                 {

--- a/DotNET/Endpoint Examples/Multipart Payload/watermarked-pdf.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/watermarked-pdf.cs
@@ -76,8 +76,12 @@ namespace Samples.EndpointExamples.MultipartPayload
                 //
                 // Deletes all files in the workflow, including outputs. Save all desired files before enabling this step.
 
-                // Toggle deletion of sensitive files (default: false)
-                var deleteSensitiveFiles = false;
+                // Optional immediate deletion of sensitive files
+                // Default: false; override with PDFREST_DELETE_SENSITIVE_FILES=true
+                var deleteSensitiveFiles = string.Equals(
+                    Environment.GetEnvironmentVariable("PDFREST_DELETE_SENSITIVE_FILES"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
 
                 if (deleteSensitiveFiles)
                 {

--- a/DotNET/Program.cs
+++ b/DotNET/Program.cs
@@ -52,7 +52,7 @@ static void PrintUsage()
     Console.Error.WriteLine("    upload <file>                      Upload file (resource id)");
     Console.Error.WriteLine("    get-resource <id> [out]            Download resource");
     Console.Error.WriteLine("    delete-resource <id>               Delete resource");
-    Console.Error.WriteLine("    batch-delete <id1> [id2] [...]     Delete multiple resources");
+    Console.Error.WriteLine("    delete <id1> [id2] [...]     Delete multiple resources");
     Console.Error.WriteLine("    zip <file1> <file2>                Zip two resources");
     Console.Error.WriteLine("    unzip <zipFile>                    Unzip resource");
     Console.Error.WriteLine("    signed-pdf <pdf> <pfx> <pass> <logo>     Sign PDF with PFX");
@@ -101,7 +101,7 @@ static void PrintUsage()
     Console.Error.WriteLine("    upload-multipart <file>            Upload file (resource id)");
     Console.Error.WriteLine("    get-resource-multipart <id> [out]  Download resource");
     Console.Error.WriteLine("    delete-resource-multipart <id>     Delete resource");
-    Console.Error.WriteLine("    batch-delete-multipart <id1> [id2] [...]  Delete multiple resources");
+    Console.Error.WriteLine("    delete-multipart <id1> [id2] [...]  Delete multiple resources");
     Console.Error.WriteLine("    zip-multipart <f1> <f2>            Zip two files");
     Console.Error.WriteLine("    unzip-multipart <zipFile>          Unzip resource");
     Console.Error.WriteLine("    signed-pdf-multipart <pdf> <pfx> <pass> <logo>    Sign PDF with PFX");
@@ -259,11 +259,11 @@ switch (cmd)
     case "delete-resource-multipart":
         await Samples.EndpointExamples.MultipartPayload.DeleteResource.Execute(rest);
         break;
-    case "batch-delete":
-        await Samples.EndpointExamples.JsonPayload.BatchDelete.Execute(rest);
+    case "delete":
+        await Samples.EndpointExamples.JsonPayload.Delete.Execute(rest);
         break;
-    case "batch-delete-multipart":
-        await Samples.EndpointExamples.MultipartPayload.BatchDelete.Execute(rest);
+    case "delete-multipart":
+        await Samples.EndpointExamples.MultipartPayload.Delete.Execute(rest);
         break;
     case "png":
         await Samples.EndpointExamples.JsonPayload.Png.Execute(rest);

--- a/DotNET/Program.cs
+++ b/DotNET/Program.cs
@@ -121,6 +121,7 @@ static void PrintUsage()
     Console.Error.WriteLine("Environment (.env supported):");
     Console.Error.WriteLine("  PDFREST_API_KEY=...    Required API key");
     Console.Error.WriteLine("  PDFREST_URL=...        Optional base URL (e.g., https://eu-api.pdfrest.com for EU/GDPR)");
+    Console.Error.WriteLine("  PDFREST_DELETE_SENSITIVE_FILES  Optional immediate deletion (true|false; default false)\n");
 }
 
 // Entry point

--- a/DotNET/README.md
+++ b/DotNET/README.md
@@ -120,7 +120,13 @@ Each script builds the project once, discovers suitable inputs inside the direct
 
 ## Optional deletion toggle
 
-- Some samples include an optional delete step to remove uploaded/generated files from pdfRest servers. This is controlled by a local `var deleteSensitiveFiles = false;` variable near the top of the file. Set it to `true` to enable deletion; it is off by default.
+- Some samples include an optional delete step to remove uploaded/generated files from pdfRest servers. By default, this is OFF. To enable immediate deletion for supported samples, set the following environment variable:
+
+  ```
+  PDFREST_DELETE_SENSITIVE_FILES=true
+  ```
+
+  If unset or set to any value other than `true` (case-insensitive), deletion remains disabled. The default behavior retains files according to the File Retention Period shown on https://pdfrest.com/pricing.
 
 ## Project Structure & Build Notes
 


### PR DESCRIPTION
PDFCLOUD-5217

- Delete sensitive files based on `PDFREST_DELETE_SENSITIVE_FILES` environment variable
- Ran `dotnet format`
- `GET /resource` doesn't require Api-Key