### PR TITLE
Remove file extension in summarized-pdf-text JSON Payload example

### DIFF
--- a/JavaScript/Endpoint Examples/JSON Payload/summarized-pdf-text.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/summarized-pdf-text.js
@@ -9,7 +9,7 @@ var apiUrl = "https://api.pdfrest.com";
  */
 //var apiUrl = "https://eu-api.pdfrest.com";
 
-var upload_data = fs.createReadStream("/path/to/file.pdf");
+var upload_data = fs.createReadStream("/path/to/file");
 
 var upload_config = {
   method: "post",


### PR DESCRIPTION
Remove file extension from createReadStream() in the summarized-pdf-text JSON Payload example to match other samples.