### PR TITLE
Add structured input endpoint examples

### DIFF
--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-csv.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-csv.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured CSV input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here
@@ -48,4 +48,3 @@ public static class PdfFromCsv
         return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
     }
 }
-

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-csv.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-csv.cs
@@ -1,0 +1,51 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-csv <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.JsonPayload;
+
+public static class PdfFromCsv
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.csv";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""csv"":{""first_row_is_header"":true,""delimiter"":"","",""columns"":[{""index"":0,""width_weight"":2,""text_align"":""left""},{""index"":1,""width_weight"":3,""text_align"":""left""},{""index"":2,""width_weight"":1,""text_align"":""right""}]}}");
+        var inputId = await UploadAsync(client, inputPath);
+        var payload = new JObject { ["id"] = inputId, ["structured_text_options"] = options };
+        using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("pdf", content);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+
+    private static async Task<string> UploadAsync(HttpClient client, string path)
+    {
+        using var content = new ByteArrayContent(await File.ReadAllBytesAsync(path));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "upload") { Content = content };
+        request.Headers.Add("Content-Filename", Path.GetFileName(path));
+        var response = await client.SendAsync(request);
+        var result = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode) throw new InvalidOperationException(result);
+        return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
+    }
+}
+

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-json.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-json.cs
@@ -1,0 +1,51 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-json <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.JsonPayload;
+
+public static class PdfFromJson
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.json";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""data_presentation"":""hierarchy""}");
+        var inputId = await UploadAsync(client, inputPath);
+        var payload = new JObject { ["id"] = inputId, ["structured_text_options"] = options };
+        using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("pdf", content);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+
+    private static async Task<string> UploadAsync(HttpClient client, string path)
+    {
+        using var content = new ByteArrayContent(await File.ReadAllBytesAsync(path));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "upload") { Content = content };
+        request.Headers.Add("Content-Filename", Path.GetFileName(path));
+        var response = await client.SendAsync(request);
+        var result = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode) throw new InvalidOperationException(result);
+        return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
+    }
+}
+

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-json.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-json.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured JSON input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here
@@ -48,4 +48,3 @@ public static class PdfFromJson
         return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
     }
 }
-

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-markdown.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-markdown.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured Markdown input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here
@@ -51,4 +51,3 @@ public static class PdfFromMarkdown
         return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
     }
 }
-

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-markdown.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-markdown.cs
@@ -1,0 +1,54 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-markdown <inputFile> <imageFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.JsonPayload;
+
+public static class PdfFromMarkdown
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.md";
+        var imagePath = args.Length > 1 ? args[1] : "/path/to/logo.png";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""markdown"":{""image_alt_text"":{""sample-logo"":""Sample logo""},""missing_image_alt_text"":""fail"",""image_sources"":{""sample-logo"":{""image_id_index"":0}}}}");
+        var inputId = await UploadAsync(client, inputPath);
+        var imageId = await UploadAsync(client, imagePath);
+        var payload = new JObject { ["id"] = inputId, ["structured_text_options"] = options };
+        payload["image_ids"] = new JArray(imageId);
+        using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("pdf", content);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+
+    private static async Task<string> UploadAsync(HttpClient client, string path)
+    {
+        using var content = new ByteArrayContent(await File.ReadAllBytesAsync(path));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "upload") { Content = content };
+        request.Headers.Add("Content-Filename", Path.GetFileName(path));
+        var response = await client.SendAsync(request);
+        var result = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode) throw new InvalidOperationException(result);
+        return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
+    }
+}
+

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-text.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-text.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts plain text input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here
@@ -48,4 +48,3 @@ public static class PdfFromText
         return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
     }
 }
-

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-text.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-text.cs
@@ -1,0 +1,51 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-text <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.JsonPayload;
+
+public static class PdfFromText
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.txt";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""plain_text"":{""line_handling"":""preserve""}}");
+        var inputId = await UploadAsync(client, inputPath);
+        var payload = new JObject { ["id"] = inputId, ["structured_text_options"] = options };
+        using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("pdf", content);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+
+    private static async Task<string> UploadAsync(HttpClient client, string path)
+    {
+        using var content = new ByteArrayContent(await File.ReadAllBytesAsync(path));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "upload") { Content = content };
+        request.Headers.Add("Content-Filename", Path.GetFileName(path));
+        var response = await client.SendAsync(request);
+        var result = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode) throw new InvalidOperationException(result);
+        return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
+    }
+}
+

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-xml.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-xml.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured XML input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here
@@ -48,4 +48,3 @@ public static class PdfFromXml
         return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
     }
 }
-

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-from-xml.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-from-xml.cs
@@ -1,0 +1,51 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-xml <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.JsonPayload;
+
+public static class PdfFromXml
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.xml";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""data_presentation"":""hierarchy""}");
+        var inputId = await UploadAsync(client, inputPath);
+        var payload = new JObject { ["id"] = inputId, ["structured_text_options"] = options };
+        using var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("pdf", content);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+
+    private static async Task<string> UploadAsync(HttpClient client, string path)
+    {
+        using var content = new ByteArrayContent(await File.ReadAllBytesAsync(path));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "upload") { Content = content };
+        request.Headers.Add("Content-Filename", Path.GetFileName(path));
+        var response = await client.SendAsync(request);
+        var result = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode) throw new InvalidOperationException(result);
+        return JObject.Parse(result)["files"]![0]!["id"]!.Value<string>()!;
+    }
+}
+

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-csv.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-csv.cs
@@ -1,0 +1,40 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-csv-multipart <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.MultipartPayload;
+
+public static class PdfFromCsv
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.csv";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""csv"":{""first_row_is_header"":true,""delimiter"":"","",""columns"":[{""index"":0,""width_weight"":2,""text_align"":""left""},{""index"":1,""width_weight"":3,""text_align"":""left""},{""index"":2,""width_weight"":1,""text_align"":""right""}]}}");
+        using var form = new MultipartFormDataContent();
+        var inputContent = new ByteArrayContent(await File.ReadAllBytesAsync(inputPath));
+        inputContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        form.Add(inputContent, "file", Path.GetFileName(inputPath));
+        form.Add(new StringContent(options.ToString()), "structured_text_options");
+        var response = await client.PostAsync("pdf", form);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+}

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-csv.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-csv.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured CSV input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-json.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-json.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured JSON input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-json.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-json.cs
@@ -1,0 +1,40 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-json-multipart <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.MultipartPayload;
+
+public static class PdfFromJson
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.json";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""data_presentation"":""hierarchy""}");
+        using var form = new MultipartFormDataContent();
+        var inputContent = new ByteArrayContent(await File.ReadAllBytesAsync(inputPath));
+        inputContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        form.Add(inputContent, "file", Path.GetFileName(inputPath));
+        form.Add(new StringContent(options.ToString()), "structured_text_options");
+        var response = await client.PostAsync("pdf", form);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+}

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-markdown.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-markdown.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured Markdown input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-markdown.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-markdown.cs
@@ -1,0 +1,44 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-markdown-multipart <inputFile> <imageFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.MultipartPayload;
+
+public static class PdfFromMarkdown
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.md";
+        var imagePath = args.Length > 1 ? args[1] : "/path/to/logo.png";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""markdown"":{""image_alt_text"":{""sample-logo"":""Sample logo""},""missing_image_alt_text"":""fail"",""image_sources"":{""sample-logo"":{""upload_index"":0}}}}");
+        using var form = new MultipartFormDataContent();
+        var inputContent = new ByteArrayContent(await File.ReadAllBytesAsync(inputPath));
+        inputContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        form.Add(inputContent, "file", Path.GetFileName(inputPath));
+        var imageContent = new ByteArrayContent(await File.ReadAllBytesAsync(imagePath));
+        imageContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        form.Add(imageContent, "image_files", Path.GetFileName(imagePath));
+        form.Add(new StringContent(options.ToString()), "structured_text_options");
+        var response = await client.PostAsync("pdf", form);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+}

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-text.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-text.cs
@@ -1,0 +1,40 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-text-multipart <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.MultipartPayload;
+
+public static class PdfFromText
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.txt";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""plain_text"":{""line_handling"":""preserve""}}");
+        using var form = new MultipartFormDataContent();
+        var inputContent = new ByteArrayContent(await File.ReadAllBytesAsync(inputPath));
+        inputContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        form.Add(inputContent, "file", Path.GetFileName(inputPath));
+        form.Add(new StringContent(options.ToString()), "structured_text_options");
+        var response = await client.PostAsync("pdf", form);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+}

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-text.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-text.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts plain text input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-xml.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-xml.cs
@@ -1,0 +1,40 @@
+/*
+ * What this sample does:
+ * - Converts structured input to PDF through the /pdf endpoint.
+ *
+ * Setup (environment):
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region.
+ *
+ * Usage:
+ *   dotnet run -- pdf-from-xml-multipart <inputFile>
+ */
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Samples.EndpointExamples.MultipartPayload;
+
+public static class PdfFromXml
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = args.Length > 0 ? args[0] : "/path/to/sample.xml";
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("Missing PDFREST_API_KEY");
+        var baseUrl = Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com";
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Api-Key", apiKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        var options = JObject.Parse(@"{""title"":""Structured Content Sample"",""language"":""en-US"",""enable_tagging"":true,""page_setup"":{""size"":""Letter"",""orientation"":""portrait"",""margin"":{""top"":36,""right"":42,""bottom"":36,""left"":42}},""style"":{""font"":""Arial"",""heading_font"":""Arial"",""code_font"":""Courier"",""text_size"":11,""text_color_rgb"":[34,34,34],""heading_scale"":1.35,""table"":{""column_width_weights"":[2,3,2],""keep_header_with_first_row"":true,""repeat_headers_on_overflow"":true,""show_borders"":true,""border_width"":0.75,""border_color_rgb"":[180,188,200],""header_fill_color_rgb"":[33,64,98],""header_text_color_rgb"":[255,255,255],""row_fill_color_rgb"":[250,250,252],""alternate_row_fill_color_rgb"":[235,240,246],""cell_padding"":{""top"":6,""right"":8,""bottom"":6,""left"":8}}},""data_presentation"":""hierarchy""}");
+        using var form = new MultipartFormDataContent();
+        var inputContent = new ByteArrayContent(await File.ReadAllBytesAsync(inputPath));
+        inputContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        form.Add(inputContent, "file", Path.GetFileName(inputPath));
+        form.Add(new StringContent(options.ToString()), "structured_text_options");
+        var response = await client.PostAsync("pdf", form);
+        var result = await response.Content.ReadAsStringAsync();
+        Console.WriteLine(result);
+        if (!response.IsSuccessStatusCode) Environment.ExitCode = 1;
+    }
+}

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-from-xml.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-from-xml.cs
@@ -1,6 +1,6 @@
 /*
  * What this sample does:
- * - Converts structured input to PDF through the /pdf endpoint.
+ * - Converts structured XML input to PDF through the /pdf endpoint.
  *
  * Setup (environment):
  * - Set PDFREST_API_KEY=your_api_key_here

--- a/DotNET/Program.cs
+++ b/DotNET/Program.cs
@@ -14,6 +14,7 @@ static void PrintUsage()
     Console.Error.WriteLine("    markdown-json <pdf>                 Convert PDF to Markdown");
     Console.Error.WriteLine("    rasterized-pdf <pdf>               Rasterize PDF pages");
     Console.Error.WriteLine("    pdf <file>                         Convert file to PDF");
+    Console.Error.WriteLine("    pdf-from-markdown|csv|json|xml|text <file>  Structured input to PDF");
     Console.Error.WriteLine("    pdfa <file>                        Convert to PDF/A");
     Console.Error.WriteLine("    pdfx <file>                        Convert to PDF/X");
     Console.Error.WriteLine("    tdm-reserved-pdf <pdf>             Apply TDM rights metadata");
@@ -66,6 +67,7 @@ static void PrintUsage()
     Console.Error.WriteLine("Multipart Payload (multipart/form-data):");
     Console.Error.WriteLine("  Conversions:");
     Console.Error.WriteLine("    pdf-multipart <file>               Convert to PDF");
+    Console.Error.WriteLine("    pdf-from-markdown|csv|json|xml|text-multipart <file>  Structured input to PDF");
     Console.Error.WriteLine("    markdown-multipart <file>          Convert to Markdown");
     Console.Error.WriteLine("    rasterized-pdf-multipart <pdf>     Rasterize PDF");
     Console.Error.WriteLine("    pdfa-multipart <file>              Convert to PDF/A");
@@ -163,6 +165,36 @@ switch (cmd)
         break;
     case "pdf-multipart":
         await Samples.EndpointExamples.MultipartPayload.Pdf.Execute(rest);
+        break;
+    case "pdf-from-markdown":
+        await Samples.EndpointExamples.JsonPayload.PdfFromMarkdown.Execute(rest);
+        break;
+    case "pdf-from-csv":
+        await Samples.EndpointExamples.JsonPayload.PdfFromCsv.Execute(rest);
+        break;
+    case "pdf-from-json":
+        await Samples.EndpointExamples.JsonPayload.PdfFromJson.Execute(rest);
+        break;
+    case "pdf-from-xml":
+        await Samples.EndpointExamples.JsonPayload.PdfFromXml.Execute(rest);
+        break;
+    case "pdf-from-text":
+        await Samples.EndpointExamples.JsonPayload.PdfFromText.Execute(rest);
+        break;
+    case "pdf-from-markdown-multipart":
+        await Samples.EndpointExamples.MultipartPayload.PdfFromMarkdown.Execute(rest);
+        break;
+    case "pdf-from-csv-multipart":
+        await Samples.EndpointExamples.MultipartPayload.PdfFromCsv.Execute(rest);
+        break;
+    case "pdf-from-json-multipart":
+        await Samples.EndpointExamples.MultipartPayload.PdfFromJson.Execute(rest);
+        break;
+    case "pdf-from-xml-multipart":
+        await Samples.EndpointExamples.MultipartPayload.PdfFromXml.Execute(rest);
+        break;
+    case "pdf-from-text-multipart":
+        await Samples.EndpointExamples.MultipartPayload.PdfFromText.Execute(rest);
         break;
     case "markdown-multipart":
         await Samples.EndpointExamples.MultipartPayload.Markdown.Execute(rest);

--- a/Java/Endpoint Examples/JSON Payload/PdfFromCsv.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromCsv.java
@@ -1,0 +1,43 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromCsv {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.csv");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");
+    String inputId = upload(inputFile, apiKey);
+    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+
+  private static String upload(File file, String apiKey) throws IOException {
+    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    OkHttpClient client = new OkHttpClient();
+    try (Response response = client.newCall(request).execute()) {
+      String body = response.body() == null ? "{}" : response.body().string();
+      if (!response.isSuccessful()) throw new IOException(body);
+      return new JSONObject(body).getJSONArray("files").getJSONObject(0).getString("id");
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/JSON Payload/PdfFromCsv.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromCsv.java
@@ -3,21 +3,31 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromCsv {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.csv");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");
     String inputId = upload(inputFile, apiKey);
-    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    JSONObject payload =
+        new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(RequestBody.create(payload.toString(), MediaType.parse("application/json")))
+            .build();
     send(request);
   }
 
@@ -31,7 +41,13 @@ public class PdfFromCsv {
   }
 
   private static String upload(File file, String apiKey) throws IOException {
-    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/upload")
+            .header("Api-Key", apiKey)
+            .header("Content-Filename", file.getName())
+            .post(RequestBody.create(file, MediaType.parse("application/octet-stream")))
+            .build();
     OkHttpClient client = new OkHttpClient();
     try (Response response = client.newCall(request).execute()) {
       String body = response.body() == null ? "{}" : response.body().string();
@@ -40,4 +56,3 @@ public class PdfFromCsv {
     }
   }
 }
-

--- a/Java/Endpoint Examples/JSON Payload/PdfFromCsv.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromCsv.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromCsv {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.csv");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");

--- a/Java/Endpoint Examples/JSON Payload/PdfFromJson.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromJson.java
@@ -1,0 +1,43 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromJson {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.json");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    String inputId = upload(inputFile, apiKey);
+    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+
+  private static String upload(File file, String apiKey) throws IOException {
+    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    OkHttpClient client = new OkHttpClient();
+    try (Response response = client.newCall(request).execute()) {
+      String body = response.body() == null ? "{}" : response.body().string();
+      if (!response.isSuccessful()) throw new IOException(body);
+      return new JSONObject(body).getJSONArray("files").getJSONObject(0).getString("id");
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/JSON Payload/PdfFromJson.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromJson.java
@@ -3,21 +3,31 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromJson {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.json");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
     String inputId = upload(inputFile, apiKey);
-    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    JSONObject payload =
+        new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(RequestBody.create(payload.toString(), MediaType.parse("application/json")))
+            .build();
     send(request);
   }
 
@@ -31,7 +41,13 @@ public class PdfFromJson {
   }
 
   private static String upload(File file, String apiKey) throws IOException {
-    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/upload")
+            .header("Api-Key", apiKey)
+            .header("Content-Filename", file.getName())
+            .post(RequestBody.create(file, MediaType.parse("application/octet-stream")))
+            .build();
     OkHttpClient client = new OkHttpClient();
     try (Response response = client.newCall(request).execute()) {
       String body = response.body() == null ? "{}" : response.body().string();
@@ -40,4 +56,3 @@ public class PdfFromJson {
     }
   }
 }
-

--- a/Java/Endpoint Examples/JSON Payload/PdfFromJson.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromJson.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromJson {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.json");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");

--- a/Java/Endpoint Examples/JSON Payload/PdfFromMarkdown.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromMarkdown.java
@@ -1,0 +1,46 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromMarkdown {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.md");
+    File imageFile = new File(args.length > 1 ? args[1] : "/path/to/logo.png");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"image_id_index\":0}}}}");
+    String inputId = upload(inputFile, apiKey);
+    String imageId = upload(imageFile, apiKey);
+    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
+    payload.put("image_ids", new JSONArray().put(imageId));
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+
+  private static String upload(File file, String apiKey) throws IOException {
+    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    OkHttpClient client = new OkHttpClient();
+    try (Response response = client.newCall(request).execute()) {
+      String body = response.body() == null ? "{}" : response.body().string();
+      if (!response.isSuccessful()) throw new IOException(body);
+      return new JSONObject(body).getJSONArray("files").getJSONObject(0).getString("id");
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/JSON Payload/PdfFromMarkdown.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromMarkdown.java
@@ -7,17 +7,14 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromMarkdown {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.md");
     File imageFile = new File(args.length > 1 ? args[1] : "/path/to/logo.png");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"image_id_index\":0}}}}");

--- a/Java/Endpoint Examples/JSON Payload/PdfFromMarkdown.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromMarkdown.java
@@ -7,20 +7,31 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromMarkdown {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.md");
     File imageFile = new File(args.length > 1 ? args[1] : "/path/to/logo.png");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"image_id_index\":0}}}}");
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"image_id_index\":0}}}}");
     String inputId = upload(inputFile, apiKey);
     String imageId = upload(imageFile, apiKey);
-    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
+    JSONObject payload =
+        new JSONObject().put("id", inputId).put("structured_text_options", options);
     payload.put("image_ids", new JSONArray().put(imageId));
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(RequestBody.create(payload.toString(), MediaType.parse("application/json")))
+            .build();
     send(request);
   }
 
@@ -34,7 +45,13 @@ public class PdfFromMarkdown {
   }
 
   private static String upload(File file, String apiKey) throws IOException {
-    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/upload")
+            .header("Api-Key", apiKey)
+            .header("Content-Filename", file.getName())
+            .post(RequestBody.create(file, MediaType.parse("application/octet-stream")))
+            .build();
     OkHttpClient client = new OkHttpClient();
     try (Response response = client.newCall(request).execute()) {
       String body = response.body() == null ? "{}" : response.body().string();
@@ -43,4 +60,3 @@ public class PdfFromMarkdown {
     }
   }
 }
-

--- a/Java/Endpoint Examples/JSON Payload/PdfFromText.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromText.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromText {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.txt");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");

--- a/Java/Endpoint Examples/JSON Payload/PdfFromText.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromText.java
@@ -1,0 +1,43 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromText {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.txt");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");
+    String inputId = upload(inputFile, apiKey);
+    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+
+  private static String upload(File file, String apiKey) throws IOException {
+    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    OkHttpClient client = new OkHttpClient();
+    try (Response response = client.newCall(request).execute()) {
+      String body = response.body() == null ? "{}" : response.body().string();
+      if (!response.isSuccessful()) throw new IOException(body);
+      return new JSONObject(body).getJSONArray("files").getJSONObject(0).getString("id");
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/JSON Payload/PdfFromText.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromText.java
@@ -3,21 +3,31 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromText {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.txt");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");
     String inputId = upload(inputFile, apiKey);
-    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    JSONObject payload =
+        new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(RequestBody.create(payload.toString(), MediaType.parse("application/json")))
+            .build();
     send(request);
   }
 
@@ -31,7 +41,13 @@ public class PdfFromText {
   }
 
   private static String upload(File file, String apiKey) throws IOException {
-    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/upload")
+            .header("Api-Key", apiKey)
+            .header("Content-Filename", file.getName())
+            .post(RequestBody.create(file, MediaType.parse("application/octet-stream")))
+            .build();
     OkHttpClient client = new OkHttpClient();
     try (Response response = client.newCall(request).execute()) {
       String body = response.body() == null ? "{}" : response.body().string();
@@ -40,4 +56,3 @@ public class PdfFromText {
     }
   }
 }
-

--- a/Java/Endpoint Examples/JSON Payload/PdfFromXml.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromXml.java
@@ -3,21 +3,31 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromXml {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.xml");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
     String inputId = upload(inputFile, apiKey);
-    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    JSONObject payload =
+        new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(RequestBody.create(payload.toString(), MediaType.parse("application/json")))
+            .build();
     send(request);
   }
 
@@ -31,7 +41,13 @@ public class PdfFromXml {
   }
 
   private static String upload(File file, String apiKey) throws IOException {
-    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/upload")
+            .header("Api-Key", apiKey)
+            .header("Content-Filename", file.getName())
+            .post(RequestBody.create(file, MediaType.parse("application/octet-stream")))
+            .build();
     OkHttpClient client = new OkHttpClient();
     try (Response response = client.newCall(request).execute()) {
       String body = response.body() == null ? "{}" : response.body().string();
@@ -40,4 +56,3 @@ public class PdfFromXml {
     }
   }
 }
-

--- a/Java/Endpoint Examples/JSON Payload/PdfFromXml.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromXml.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromXml {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.xml");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");

--- a/Java/Endpoint Examples/JSON Payload/PdfFromXml.java
+++ b/Java/Endpoint Examples/JSON Payload/PdfFromXml.java
@@ -1,0 +1,43 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromXml {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.xml");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    String inputId = upload(inputFile, apiKey);
+    JSONObject payload = new JSONObject().put("id", inputId).put("structured_text_options", options);
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(RequestBody.create(payload.toString(), MediaType.parse("application/json"))).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+
+  private static String upload(File file, String apiKey) throws IOException {
+    Request request = new Request.Builder().url(API_URL + "/upload").header("Api-Key", apiKey).header("Content-Filename", file.getName()).post(RequestBody.create(file, MediaType.parse("application/octet-stream"))).build();
+    OkHttpClient client = new OkHttpClient();
+    try (Response response = client.newCall(request).execute()) {
+      String body = response.body() == null ? "{}" : response.body().string();
+      if (!response.isSuccessful()) throw new IOException(body);
+      return new JSONObject(body).getJSONArray("files").getJSONObject(0).getString("id");
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromCsv.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromCsv.java
@@ -1,0 +1,34 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromCsv {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.csv");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");
+    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
+        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+        .addFormDataPart("structured_text_options", options.toString());
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromCsv.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromCsv.java
@@ -3,22 +3,36 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromCsv {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.csv");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");
-    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
-        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
-        .addFormDataPart("structured_text_options", options.toString());
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");
+    MultipartBody.Builder form =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "file",
+                inputFile.getName(),
+                RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+            .addFormDataPart("structured_text_options", options.toString());
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(form.build())
+            .build();
     send(request);
   }
 
@@ -31,4 +45,3 @@ public class PdfFromCsv {
     }
   }
 }
-

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromCsv.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromCsv.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromCsv {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.csv");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"csv\":{\"first_row_is_header\":true,\"delimiter\":\",\",\"columns\":[{\"index\":0,\"width_weight\":2,\"text_align\":\"left\"},{\"index\":1,\"width_weight\":3,\"text_align\":\"left\"},{\"index\":2,\"width_weight\":1,\"text_align\":\"right\"}]}}");

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromJson.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromJson.java
@@ -3,22 +3,36 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromJson {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.json");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
-    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
-        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
-        .addFormDataPart("structured_text_options", options.toString());
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    MultipartBody.Builder form =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "file",
+                inputFile.getName(),
+                RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+            .addFormDataPart("structured_text_options", options.toString());
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(form.build())
+            .build();
     send(request);
   }
 
@@ -31,4 +45,3 @@ public class PdfFromJson {
     }
   }
 }
-

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromJson.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromJson.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromJson {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.json");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromJson.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromJson.java
@@ -1,0 +1,34 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromJson {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.json");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
+        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+        .addFormDataPart("structured_text_options", options.toString());
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromMarkdown.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromMarkdown.java
@@ -3,24 +3,41 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromMarkdown {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.md");
     File imageFile = new File(args.length > 1 ? args[1] : "/path/to/logo.png");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"upload_index\":0}}}}");
-    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
-        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
-        .addFormDataPart("image_files", imageFile.getName(), RequestBody.create(imageFile, MediaType.parse("image/png")))
-        .addFormDataPart("structured_text_options", options.toString());
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"upload_index\":0}}}}");
+    MultipartBody.Builder form =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "file",
+                inputFile.getName(),
+                RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+            .addFormDataPart(
+                "image_files",
+                imageFile.getName(),
+                RequestBody.create(imageFile, MediaType.parse("image/png")))
+            .addFormDataPart("structured_text_options", options.toString());
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(form.build())
+            .build();
     send(request);
   }
 
@@ -33,4 +50,3 @@ public class PdfFromMarkdown {
     }
   }
 }
-

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromMarkdown.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromMarkdown.java
@@ -6,17 +6,14 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromMarkdown {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.md");
     File imageFile = new File(args.length > 1 ? args[1] : "/path/to/logo.png");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"upload_index\":0}}}}");

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromMarkdown.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromMarkdown.java
@@ -1,0 +1,36 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromMarkdown {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.md");
+    File imageFile = new File(args.length > 1 ? args[1] : "/path/to/logo.png");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"markdown\":{\"image_alt_text\":{\"sample-logo\":\"Sample logo\"},\"missing_image_alt_text\":\"fail\",\"image_sources\":{\"sample-logo\":{\"upload_index\":0}}}}");
+    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
+        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+        .addFormDataPart("image_files", imageFile.getName(), RequestBody.create(imageFile, MediaType.parse("image/png")))
+        .addFormDataPart("structured_text_options", options.toString());
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromText.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromText.java
@@ -3,22 +3,36 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromText {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.txt");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");
-    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
-        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
-        .addFormDataPart("structured_text_options", options.toString());
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");
+    MultipartBody.Builder form =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "file",
+                inputFile.getName(),
+                RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+            .addFormDataPart("structured_text_options", options.toString());
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(form.build())
+            .build();
     send(request);
   }
 
@@ -31,4 +45,3 @@ public class PdfFromText {
     }
   }
 }
-

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromText.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromText.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromText {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.txt");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromText.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromText.java
@@ -1,0 +1,34 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromText {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.txt");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"plain_text\":{\"line_handling\":\"preserve\"}}");
+    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
+        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+        .addFormDataPart("structured_text_options", options.toString());
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromXml.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromXml.java
@@ -6,16 +6,13 @@ import okhttp3.*;
 import org.json.JSONObject;
 
 public class PdfFromXml {
-  private static final String API_URL =
-      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL = "https://api.pdfrest.com";
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.xml");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey =
-        dotenv.get(
-            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
     JSONObject options =
         new JSONObject(
             "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromXml.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromXml.java
@@ -1,0 +1,34 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PdfFromXml {
+  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) throws IOException {
+    File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.xml");
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
+        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+        .addFormDataPart("structured_text_options", options.toString());
+    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    send(request);
+  }
+
+  private static void send(Request request) throws IOException {
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Result code " + response.code());
+      if (response.body() != null) System.out.println(response.body().string());
+      if (!response.isSuccessful()) System.exit(1);
+    }
+  }
+}
+

--- a/Java/Endpoint Examples/Multipart Payload/PdfFromXml.java
+++ b/Java/Endpoint Examples/Multipart Payload/PdfFromXml.java
@@ -3,22 +3,36 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.*;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class PdfFromXml {
-  private static final String API_URL = System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
+  private static final String API_URL =
+      System.getenv().getOrDefault("PDFREST_URL", "https://api.pdfrest.com");
   private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
 
   public static void main(String[] args) throws IOException {
     File inputFile = new File(args.length > 0 ? args[0] : "/path/to/sample.xml");
     Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
-    String apiKey = dotenv.get("PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
-    JSONObject options = new JSONObject("{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
-    MultipartBody.Builder form = new MultipartBody.Builder().setType(MultipartBody.FORM)
-        .addFormDataPart("file", inputFile.getName(), RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
-        .addFormDataPart("structured_text_options", options.toString());
-    Request request = new Request.Builder().url(API_URL + "/pdf").header("Api-Key", apiKey).post(form.build()).build();
+    String apiKey =
+        dotenv.get(
+            "PDFREST_API_KEY", System.getenv().getOrDefault("PDFREST_API_KEY", DEFAULT_API_KEY));
+    JSONObject options =
+        new JSONObject(
+            "{\"title\":\"Structured Content Sample\",\"language\":\"en-US\",\"enable_tagging\":true,\"page_setup\":{\"size\":\"Letter\",\"orientation\":\"portrait\",\"margin\":{\"top\":36,\"right\":42,\"bottom\":36,\"left\":42}},\"style\":{\"font\":\"Arial\",\"heading_font\":\"Arial\",\"code_font\":\"Courier\",\"text_size\":11,\"text_color_rgb\":[34,34,34],\"heading_scale\":1.35,\"table\":{\"column_width_weights\":[2,3,2],\"keep_header_with_first_row\":true,\"repeat_headers_on_overflow\":true,\"show_borders\":true,\"border_width\":0.75,\"border_color_rgb\":[180,188,200],\"header_fill_color_rgb\":[33,64,98],\"header_text_color_rgb\":[255,255,255],\"row_fill_color_rgb\":[250,250,252],\"alternate_row_fill_color_rgb\":[235,240,246],\"cell_padding\":{\"top\":6,\"right\":8,\"bottom\":6,\"left\":8}}},\"data_presentation\":\"hierarchy\"}");
+    MultipartBody.Builder form =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart(
+                "file",
+                inputFile.getName(),
+                RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+            .addFormDataPart("structured_text_options", options.toString());
+    Request request =
+        new Request.Builder()
+            .url(API_URL + "/pdf")
+            .header("Api-Key", apiKey)
+            .post(form.build())
+            .build();
     send(request);
   }
 
@@ -31,4 +45,3 @@ public class PdfFromXml {
     }
   }
 }
-

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-csv.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-csv.js
@@ -1,0 +1,25 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample uploads CSV input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.csv";
+async function upload(path) {
+  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  return response.data.files[0].id;
+}
+
+async function main() {
+  const inputId = await upload(inputPath);
+  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}} };
+  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  console.log(JSON.stringify(response.data, null, 2));
+}
+
+main().catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-csv.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-csv.js
@@ -1,23 +1,27 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample uploads CSV input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.csv";
+var inputPath = "/path/to/sample.csv";
 async function upload(path) {
-  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  var response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
   return response.data.files[0].id;
 }
 
 async function main() {
-  const inputId = await upload(inputPath);
-  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}} };
-  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  var inputId = await upload(inputPath);
+  var payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}} };
+  var response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/json" } });
   console.log(JSON.stringify(response.data, null, 2));
 }
 

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-json.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-json.js
@@ -1,0 +1,25 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample uploads JSON input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.json";
+async function upload(path) {
+  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  return response.data.files[0].id;
+}
+
+async function main() {
+  const inputId = await upload(inputPath);
+  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"} };
+  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  console.log(JSON.stringify(response.data, null, 2));
+}
+
+main().catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-json.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-json.js
@@ -1,23 +1,27 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample uploads JSON input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.json";
+var inputPath = "/path/to/sample.json";
 async function upload(path) {
-  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  var response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
   return response.data.files[0].id;
 }
 
 async function main() {
-  const inputId = await upload(inputPath);
-  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"} };
-  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  var inputId = await upload(inputPath);
+  var payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"} };
+  var response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/json" } });
   console.log(JSON.stringify(response.data, null, 2));
 }
 

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-markdown.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-markdown.js
@@ -1,0 +1,28 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample uploads Markdown input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options, tagged Markdown image mapping, and input/output resource IDs.
+const inputPath = process.argv[2] || "/path/to/sample.md";
+const imagePath = process.argv[3] || "/path/to/logo.png";
+async function upload(path) {
+  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  return response.data.files[0].id;
+}
+
+async function main() {
+  const inputId = await upload(inputPath);
+  const imageId = await upload(imagePath);
+  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"image_id_index":0}}}} };
+  payload.image_ids = [imageId];
+  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  console.log(JSON.stringify(response.data, null, 2));
+}
+
+main().catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-markdown.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-markdown.js
@@ -1,26 +1,30 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample uploads Markdown input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options, tagged Markdown image mapping, and input/output resource IDs.
-const inputPath = process.argv[2] || "/path/to/sample.md";
-const imagePath = process.argv[3] || "/path/to/logo.png";
+var inputPath = "/path/to/sample.md";
+var imagePath = "/path/to/logo.png";
 async function upload(path) {
-  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  var response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
   return response.data.files[0].id;
 }
 
 async function main() {
-  const inputId = await upload(inputPath);
-  const imageId = await upload(imagePath);
-  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"image_id_index":0}}}} };
+  var inputId = await upload(inputPath);
+  var imageId = await upload(imagePath);
+  var payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"image_id_index":0}}}} };
   payload.image_ids = [imageId];
-  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  var response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/json" } });
   console.log(JSON.stringify(response.data, null, 2));
 }
 

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-text.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-text.js
@@ -1,0 +1,25 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample uploads plain text input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.txt";
+async function upload(path) {
+  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  return response.data.files[0].id;
+}
+
+async function main() {
+  const inputId = await upload(inputPath);
+  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}} };
+  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  console.log(JSON.stringify(response.data, null, 2));
+}
+
+main().catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-text.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-text.js
@@ -1,23 +1,27 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample uploads plain text input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.txt";
+var inputPath = "/path/to/sample.text";
 async function upload(path) {
-  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  var response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
   return response.data.files[0].id;
 }
 
 async function main() {
-  const inputId = await upload(inputPath);
-  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}} };
-  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  var inputId = await upload(inputPath);
+  var payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}} };
+  var response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/json" } });
   console.log(JSON.stringify(response.data, null, 2));
 }
 

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-text.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-text.js
@@ -12,7 +12,7 @@ var apiUrl = "https://api.pdfrest.com";
 
 // This sample uploads plain text input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
-var inputPath = "/path/to/sample.text";
+var inputPath = "/path/to/sample.txt";
 async function upload(path) {
   var response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
   return response.data.files[0].id;
@@ -26,4 +26,3 @@ async function main() {
 }
 
 main().catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
-

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-xml.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-xml.js
@@ -1,0 +1,25 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample uploads XML input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.xml";
+async function upload(path) {
+  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  return response.data.files[0].id;
+}
+
+async function main() {
+  const inputId = await upload(inputPath);
+  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"} };
+  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  console.log(JSON.stringify(response.data, null, 2));
+}
+
+main().catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-from-xml.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-from-xml.js
@@ -1,23 +1,27 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample uploads XML input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.xml";
+var inputPath = "/path/to/sample.xml";
 async function upload(path) {
-  const response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": apiKey, "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
+  var response = await axios.post(apiUrl + "/upload", fs.createReadStream(path), { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/octet-stream", "Content-Filename": path.split("/").pop() }, maxBodyLength: Infinity });
   return response.data.files[0].id;
 }
 
 async function main() {
-  const inputId = await upload(inputPath);
-  const payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"} };
-  const response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": apiKey, "Content-Type": "application/json" } });
+  var inputId = await upload(inputPath);
+  var payload = { id: inputId, structured_text_options: {"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"} };
+  var response = await axios.post(apiUrl + "/pdf", payload, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "Content-Type": "application/json" } });
   console.log(JSON.stringify(response.data, null, 2));
 }
 

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-csv.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-csv.js
@@ -1,20 +1,24 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample converts CSV input to a tagged PDF through multipart /pdf.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.csv";
-const form = new FormData();
+var inputPath = "/path/to/sample.csv";
+var form = new FormData();
 form.append("file", fs.createReadStream(inputPath));
 form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}));
 form.append("output", "pdf_from_csv");
 
-axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", ...form.getHeaders() }, maxBodyLength: Infinity })
 .then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
 .catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
 

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-csv.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-csv.js
@@ -1,0 +1,20 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample converts CSV input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.csv";
+const form = new FormData();
+form.append("file", fs.createReadStream(inputPath));
+form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}));
+form.append("output", "pdf_from_csv");
+
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+.then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
+.catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-json.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-json.js
@@ -1,0 +1,20 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample converts JSON input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.json";
+const form = new FormData();
+form.append("file", fs.createReadStream(inputPath));
+form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}));
+form.append("output", "pdf_from_json");
+
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+.then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
+.catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-json.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-json.js
@@ -1,20 +1,24 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample converts JSON input to a tagged PDF through multipart /pdf.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.json";
-const form = new FormData();
+var inputPath = "/path/to/sample.json";
+var form = new FormData();
 form.append("file", fs.createReadStream(inputPath));
 form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}));
 form.append("output", "pdf_from_json");
 
-axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", ...form.getHeaders() }, maxBodyLength: Infinity })
 .then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
 .catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
 

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-markdown.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-markdown.js
@@ -1,0 +1,22 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample converts Markdown input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options, table styling, tagging, and uploaded Markdown image mapping.
+const inputPath = process.argv[2] || "/path/to/sample.md";
+const imagePath = process.argv[3] || "/path/to/logo.png";
+const form = new FormData();
+form.append("file", fs.createReadStream(inputPath));
+form.append("image_files", fs.createReadStream(imagePath));
+form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"upload_index":0}}}}));
+form.append("output", "pdf_from_markdown");
+
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+.then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
+.catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-markdown.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-markdown.js
@@ -1,22 +1,26 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample converts Markdown input to a tagged PDF through multipart /pdf.
 // It demonstrates structured_text_options, table styling, tagging, and uploaded Markdown image mapping.
-const inputPath = process.argv[2] || "/path/to/sample.md";
-const imagePath = process.argv[3] || "/path/to/logo.png";
-const form = new FormData();
+var inputPath = "/path/to/sample.md";
+var imagePath = "/path/to/logo.png";
+var form = new FormData();
 form.append("file", fs.createReadStream(inputPath));
 form.append("image_files", fs.createReadStream(imagePath));
 form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"upload_index":0}}}}));
 form.append("output", "pdf_from_markdown");
 
-axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", ...form.getHeaders() }, maxBodyLength: Infinity })
 .then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
 .catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
 

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-text.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-text.js
@@ -1,0 +1,20 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample converts plain text input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.txt";
+const form = new FormData();
+form.append("file", fs.createReadStream(inputPath));
+form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}));
+form.append("output", "pdf_from_text");
+
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+.then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
+.catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-text.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-text.js
@@ -12,7 +12,7 @@ var apiUrl = "https://api.pdfrest.com";
 
 // This sample converts plain text input to a tagged PDF through multipart /pdf.
 // It demonstrates structured_text_options and the format-specific conversion options.
-var inputPath = "/path/to/sample.text";
+var inputPath = "/path/to/sample.txt";
 var form = new FormData();
 form.append("file", fs.createReadStream(inputPath));
 form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}));
@@ -21,4 +21,3 @@ form.append("output", "pdf_from_text");
 axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", ...form.getHeaders() }, maxBodyLength: Infinity })
 .then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
 .catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
-

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-text.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-text.js
@@ -1,20 +1,24 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample converts plain text input to a tagged PDF through multipart /pdf.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.txt";
-const form = new FormData();
+var inputPath = "/path/to/sample.text";
+var form = new FormData();
 form.append("file", fs.createReadStream(inputPath));
 form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}));
 form.append("output", "pdf_from_text");
 
-axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", ...form.getHeaders() }, maxBodyLength: Infinity })
 .then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
 .catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
 

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-xml.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-xml.js
@@ -1,20 +1,24 @@
-const axios = require("axios");
-const fs = require("fs");
-const FormData = require("form-data");
+var axios = require("axios");
+var fs = require("fs");
+var FormData = require("form-data");
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
-const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+var apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//var apiUrl = "https://eu-api.pdfrest.com";
 
 // This sample converts XML input to a tagged PDF through multipart /pdf.
 // It demonstrates structured_text_options and the format-specific conversion options.
-const inputPath = process.argv[2] || "/path/to/sample.xml";
-const form = new FormData();
+var inputPath = "/path/to/sample.xml";
+var form = new FormData();
 form.append("file", fs.createReadStream(inputPath));
 form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}));
 form.append("output", "pdf_from_xml");
 
-axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", ...form.getHeaders() }, maxBodyLength: Infinity })
 .then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
 .catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
 

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-xml.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-from-xml.js
@@ -1,0 +1,20 @@
+const axios = require("axios");
+const fs = require("fs");
+const FormData = require("form-data");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = process.env.PDFREST_URL || "https://api.pdfrest.com";
+const apiKey = process.env.PDFREST_API_KEY || "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+// This sample converts XML input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+const inputPath = process.argv[2] || "/path/to/sample.xml";
+const form = new FormData();
+form.append("file", fs.createReadStream(inputPath));
+form.append("structured_text_options", JSON.stringify({"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}));
+form.append("output", "pdf_from_xml");
+
+axios.post(apiUrl + "/pdf", form, { headers: { "Api-Key": apiKey, ...form.getHeaders() }, maxBodyLength: Infinity })
+.then((response) => { console.log(JSON.stringify(response.data, null, 2)); })
+.catch((error) => { console.error(error.response ? error.response.data : error.message); process.exitCode = 1; });
+

--- a/JavaScript/package-lock.json
+++ b/JavaScript/package-lock.json
@@ -5,7 +5,64 @@
   "packages": {
     "": {
       "dependencies": {
+        "axios": "^1.16.0",
+        "form-data": "^4.0.0",
         "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -14,6 +71,91 @@
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/fetch-blob": {
@@ -38,6 +180,42 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -48,6 +226,152 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -84,6 +408,15 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -94,10 +427,103 @@
     }
   },
   "dependencies": {
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "requires": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
+    "debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "requires": {
+        "ms": "^2.1.3"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
     },
     "fetch-blob": {
       "version": "3.2.0",
@@ -108,6 +534,23 @@
         "web-streams-polyfill": "^3.0.3"
       }
     },
+    "follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
+    },
+    "form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      }
+    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -115,6 +558,95 @@
       "requires": {
         "fetch-blob": "^3.1.2"
       }
+    },
+    "function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node-domexception": {
       "version": "1.0.0",
@@ -130,6 +662,11 @@
         "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
       }
+    },
+    "proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
     "web-streams-polyfill": {
       "version": "3.2.1",

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "axios": "^1.16.0",
+    "form-data": "^4.0.0",
     "node-fetch": "^3.3.2"
   }
 }

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-csv.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-csv.php
@@ -6,22 +6,26 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.csv';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.csv';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}', true);
 
 // This sample uploads CSV input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
 $client = new Client(['http_errors' => false]);
-$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
-  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+$upload = function (string $path) use ($client, $apiUrl): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
   $body = json_decode((string) $response->getBody(), true);
   return $body['files'][0]['id'];
 };
 $inputId = $upload($inputPath);
 $payload = ['id' => $inputId, 'structured_text_options' => $options];
-$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-csv.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-csv.php
@@ -1,0 +1,27 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.csv';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}', true);
+
+// This sample uploads CSV input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$client = new Client(['http_errors' => false]);
+$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+  $body = json_decode((string) $response->getBody(), true);
+  return $body['files'][0]['id'];
+};
+$inputId = $upload($inputPath);
+$payload = ['id' => $inputId, 'structured_text_options' => $options];
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-json.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-json.php
@@ -1,0 +1,27 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.json';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
+
+// This sample uploads JSON input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$client = new Client(['http_errors' => false]);
+$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+  $body = json_decode((string) $response->getBody(), true);
+  return $body['files'][0]['id'];
+};
+$inputId = $upload($inputPath);
+$payload = ['id' => $inputId, 'structured_text_options' => $options];
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-json.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-json.php
@@ -6,22 +6,26 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.json';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.json';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
 
 // This sample uploads JSON input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
 $client = new Client(['http_errors' => false]);
-$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
-  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+$upload = function (string $path) use ($client, $apiUrl): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
   $body = json_decode((string) $response->getBody(), true);
   return $body['files'][0]['id'];
 };
 $inputId = $upload($inputPath);
 $payload = ['id' => $inputId, 'structured_text_options' => $options];
-$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-markdown.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-markdown.php
@@ -6,18 +6,22 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.md';
-$imagePath = $argv[2] ?? '/path/to/logo.png';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.md';
+$imagePath = '/path/to/logo.png';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"image_id_index":0}}}}', true);
 
 // This sample uploads Markdown input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options, tagged Markdown image mapping, and input/output resource IDs.
 $client = new Client(['http_errors' => false]);
-$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
-  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+$upload = function (string $path) use ($client, $apiUrl): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
   $body = json_decode((string) $response->getBody(), true);
   return $body['files'][0]['id'];
 };
@@ -25,6 +29,6 @@ $inputId = $upload($inputPath);
 $imageId = $upload($imagePath);
 $payload = ['id' => $inputId, 'structured_text_options' => $options];
 $payload['image_ids'] = [$imageId];
-$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-markdown.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-markdown.php
@@ -1,0 +1,30 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.md';
+$imagePath = $argv[2] ?? '/path/to/logo.png';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"image_id_index":0}}}}', true);
+
+// This sample uploads Markdown input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options, tagged Markdown image mapping, and input/output resource IDs.
+$client = new Client(['http_errors' => false]);
+$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+  $body = json_decode((string) $response->getBody(), true);
+  return $body['files'][0]['id'];
+};
+$inputId = $upload($inputPath);
+$imageId = $upload($imagePath);
+$payload = ['id' => $inputId, 'structured_text_options' => $options];
+$payload['image_ids'] = [$imageId];
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-text.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-text.php
@@ -1,0 +1,27 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.txt';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}', true);
+
+// This sample uploads plain text input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$client = new Client(['http_errors' => false]);
+$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+  $body = json_decode((string) $response->getBody(), true);
+  return $body['files'][0]['id'];
+};
+$inputId = $upload($inputPath);
+$payload = ['id' => $inputId, 'structured_text_options' => $options];
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-text.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-text.php
@@ -6,22 +6,26 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.txt';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.txt';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}', true);
 
 // This sample uploads plain text input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
 $client = new Client(['http_errors' => false]);
-$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
-  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+$upload = function (string $path) use ($client, $apiUrl): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
   $body = json_decode((string) $response->getBody(), true);
   return $body['files'][0]['id'];
 };
 $inputId = $upload($inputPath);
 $payload = ['id' => $inputId, 'structured_text_options' => $options];
-$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-xml.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-xml.php
@@ -1,0 +1,27 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.xml';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
+
+// This sample uploads XML input, then calls /pdf with a JSON payload.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$client = new Client(['http_errors' => false]);
+$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+  $body = json_decode((string) $response->getBody(), true);
+  return $body['files'][0]['id'];
+};
+$inputId = $upload($inputPath);
+$payload = ['id' => $inputId, 'structured_text_options' => $options];
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/JSON Payload/pdf-from-xml.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-from-xml.php
@@ -6,22 +6,26 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.xml';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.xml';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
 
 // This sample uploads XML input, then calls /pdf with a JSON payload.
 // It demonstrates structured_text_options and the format-specific conversion options.
 $client = new Client(['http_errors' => false]);
-$upload = function (string $path) use ($client, $apiUrl, $apiKey): string {
-  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
+$upload = function (string $path) use ($client, $apiUrl): string {
+  $response = $client->post($apiUrl . '/upload', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/octet-stream', 'Content-Filename' => basename($path)], 'body' => Utils::tryFopen($path, 'r')]);
   $body = json_decode((string) $response->getBody(), true);
   return $body['files'][0]['id'];
 };
 $inputId = $upload($inputPath);
 $payload = ['id' => $inputId, 'structured_text_options' => $options];
-$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
+$response = $client->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Content-Type' => 'application/json', 'Accept' => 'application/json'], 'json' => $payload]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-csv.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-csv.php
@@ -6,10 +6,14 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.csv';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.csv';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}', true);
 
 // This sample converts CSV input to a tagged PDF through multipart /pdf.
@@ -19,6 +23,6 @@ $multipart = [
   ['name' => 'structured_text_options', 'contents' => json_encode($options)],
   ['name' => 'output', 'contents' => 'pdf_from_csv'],
 ];
-$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Accept' => 'application/json'], 'multipart' => $multipart]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-csv.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-csv.php
@@ -1,0 +1,24 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.csv';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}', true);
+
+// This sample converts CSV input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$multipart = [
+  ['name' => 'file', 'contents' => Utils::tryFopen($inputPath, 'r'), 'filename' => basename($inputPath)],
+  ['name' => 'structured_text_options', 'contents' => json_encode($options)],
+  ['name' => 'output', 'contents' => 'pdf_from_csv'],
+];
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-json.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-json.php
@@ -1,0 +1,24 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.json';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
+
+// This sample converts JSON input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$multipart = [
+  ['name' => 'file', 'contents' => Utils::tryFopen($inputPath, 'r'), 'filename' => basename($inputPath)],
+  ['name' => 'structured_text_options', 'contents' => json_encode($options)],
+  ['name' => 'output', 'contents' => 'pdf_from_json'],
+];
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-json.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-json.php
@@ -6,10 +6,14 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.json';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.json';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
 
 // This sample converts JSON input to a tagged PDF through multipart /pdf.
@@ -19,6 +23,6 @@ $multipart = [
   ['name' => 'structured_text_options', 'contents' => json_encode($options)],
   ['name' => 'output', 'contents' => 'pdf_from_json'],
 ];
-$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Accept' => 'application/json'], 'multipart' => $multipart]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-markdown.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-markdown.php
@@ -6,11 +6,15 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.md';
-$imagePath = $argv[2] ?? '/path/to/logo.png';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.md';
+$imagePath = '/path/to/logo.png';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"upload_index":0}}}}', true);
 
 // This sample converts Markdown input to a tagged PDF through multipart /pdf.
@@ -21,6 +25,6 @@ $multipart = [
   ['name' => 'structured_text_options', 'contents' => json_encode($options)],
   ['name' => 'output', 'contents' => 'pdf_from_markdown'],
 ];
-$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Accept' => 'application/json'], 'multipart' => $multipart]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-markdown.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-markdown.php
@@ -1,0 +1,26 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.md';
+$imagePath = $argv[2] ?? '/path/to/logo.png';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"upload_index":0}}}}', true);
+
+// This sample converts Markdown input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options, table styling, tagging, and uploaded Markdown image mapping.
+$multipart = [
+  ['name' => 'file', 'contents' => Utils::tryFopen($inputPath, 'r'), 'filename' => basename($inputPath)],
+  ['name' => 'image_files', 'contents' => Utils::tryFopen($imagePath, 'r'), 'filename' => basename($imagePath)],
+  ['name' => 'structured_text_options', 'contents' => json_encode($options)],
+  ['name' => 'output', 'contents' => 'pdf_from_markdown'],
+];
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-text.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-text.php
@@ -6,10 +6,14 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.txt';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.txt';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}', true);
 
 // This sample converts plain text input to a tagged PDF through multipart /pdf.
@@ -19,6 +23,6 @@ $multipart = [
   ['name' => 'structured_text_options', 'contents' => json_encode($options)],
   ['name' => 'output', 'contents' => 'pdf_from_text'],
 ];
-$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Accept' => 'application/json'], 'multipart' => $multipart]);
 echo $response->getBody();
 

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-text.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-text.php
@@ -1,0 +1,24 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.txt';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}', true);
+
+// This sample converts plain text input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$multipart = [
+  ['name' => 'file', 'contents' => Utils::tryFopen($inputPath, 'r'), 'filename' => basename($inputPath)],
+  ['name' => 'structured_text_options', 'contents' => json_encode($options)],
+  ['name' => 'output', 'contents' => 'pdf_from_text'],
+];
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-xml.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-xml.php
@@ -1,0 +1,24 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
+$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+
+$inputPath = $argv[1] ?? '/path/to/sample.xml';
+$options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
+
+// This sample converts XML input to a tagged PDF through multipart /pdf.
+// It demonstrates structured_text_options and the format-specific conversion options.
+$multipart = [
+  ['name' => 'file', 'contents' => Utils::tryFopen($inputPath, 'r'), 'filename' => basename($inputPath)],
+  ['name' => 'structured_text_options', 'contents' => json_encode($options)],
+  ['name' => 'output', 'contents' => 'pdf_from_xml'],
+];
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+echo $response->getBody();
+

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-from-xml.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-from-xml.php
@@ -6,10 +6,14 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 
 // By default, we use the US-based API service. This is the primary endpoint for global use.
-$apiUrl = getenv('PDFREST_URL') ?: 'https://api.pdfrest.com';
-$apiKey = getenv('PDFREST_API_KEY') ?: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+$apiUrl = "https://api.pdfrest.com";
 
-$inputPath = $argv[1] ?? '/path/to/sample.xml';
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+//$apiUrl = "https://eu-api.pdfrest.com";
+
+$inputPath = '/path/to/sample.xml';
 $options = json_decode('{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}', true);
 
 // This sample converts XML input to a tagged PDF through multipart /pdf.
@@ -19,6 +23,6 @@ $multipart = [
   ['name' => 'structured_text_options', 'contents' => json_encode($options)],
   ['name' => 'output', 'contents' => 'pdf_from_xml'],
 ];
-$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => $apiKey, 'Accept' => 'application/json'], 'multipart' => $multipart]);
+$response = (new Client())->post($apiUrl . '/pdf', ['headers' => ['Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Accept' => 'application/json'], 'multipart' => $multipart]);
 echo $response->getBody();
 

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-csv.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-csv.py
@@ -1,0 +1,132 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample uploads CSV input, then calls /pdf with a JSON payload.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.csv"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+
+def upload(path):
+    with open(path, "rb") as source:
+        response = requests.post(api_url + "/upload", data=source, headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Filename": os.path.basename(path),
+            "Api-Key": api_key,
+        })
+    if not response.ok:
+        print(response.text)
+        raise SystemExit(1)
+    return response.json()["files"][0]["id"]
+
+input_id = upload(input_path)
+payload = {
+    "id": input_id,
+    "structured_text_options": json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "csv": {
+    "first_row_is_header": true,
+    "delimiter": ",",
+    "columns": [
+      {
+        "index": 0,
+        "width_weight": 2,
+        "text_align": "left"
+      },
+      {
+        "index": 1,
+        "width_weight": 3,
+        "text_align": "left"
+      },
+      {
+        "index": 2,
+        "width_weight": 1,
+        "text_align": "right"
+      }
+    ]
+  }
+}'''),
+}
+response = requests.post(api_url + "/pdf", json=payload, headers={
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Api-Key": api_key,
+})
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-csv.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-csv.py
@@ -1,22 +1,24 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample uploads CSV input, then calls /pdf with a JSON payload.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.csv"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.csv"
 
 def upload(path):
     with open(path, "rb") as source:
         response = requests.post(api_url + "/upload", data=source, headers={
             "Content-Type": "application/octet-stream",
             "Content-Filename": os.path.basename(path),
-            "Api-Key": api_key,
+            "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         })
     if not response.ok:
         print(response.text)
@@ -120,7 +122,7 @@ payload = {
 response = requests.post(api_url + "/pdf", json=payload, headers={
     "Accept": "application/json",
     "Content-Type": "application/json",
-    "Api-Key": api_key,
+    "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-json.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-json.py
@@ -1,22 +1,24 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample uploads JSON input, then calls /pdf with a JSON payload.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.json"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.json"
 
 def upload(path):
     with open(path, "rb") as source:
         response = requests.post(api_url + "/upload", data=source, headers={
             "Content-Type": "application/octet-stream",
             "Content-Filename": os.path.basename(path),
-            "Api-Key": api_key,
+            "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         })
     if not response.ok:
         print(response.text)
@@ -100,7 +102,7 @@ payload = {
 response = requests.post(api_url + "/pdf", json=payload, headers={
     "Accept": "application/json",
     "Content-Type": "application/json",
-    "Api-Key": api_key,
+    "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-json.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-json.py
@@ -1,0 +1,112 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample uploads JSON input, then calls /pdf with a JSON payload.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.json"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+
+def upload(path):
+    with open(path, "rb") as source:
+        response = requests.post(api_url + "/upload", data=source, headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Filename": os.path.basename(path),
+            "Api-Key": api_key,
+        })
+    if not response.ok:
+        print(response.text)
+        raise SystemExit(1)
+    return response.json()["files"][0]["id"]
+
+input_id = upload(input_path)
+payload = {
+    "id": input_id,
+    "structured_text_options": json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "data_presentation": "hierarchy"
+}'''),
+}
+response = requests.post(api_url + "/pdf", json=payload, headers={
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Api-Key": api_key,
+})
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-markdown.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-markdown.py
@@ -1,23 +1,25 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample uploads Markdown input, then calls /pdf with a JSON payload.
 # It demonstrates structured_text_options, tagged Markdown image mapping, and input/output resource IDs.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.md"
-image_path = sys.argv[2] if len(sys.argv) > 2 else "/path/to/logo.png"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.md"
+image_path = "/path/to/logo.png"
 
 def upload(path):
     with open(path, "rb") as source:
         response = requests.post(api_url + "/upload", data=source, headers={
             "Content-Type": "application/octet-stream",
             "Content-Filename": os.path.basename(path),
-            "Api-Key": api_key,
+            "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         })
     if not response.ok:
         print(response.text)
@@ -113,7 +115,7 @@ payload["image_ids"] = [image_id]
 response = requests.post(api_url + "/pdf", json=payload, headers={
     "Accept": "application/json",
     "Content-Type": "application/json",
-    "Api-Key": api_key,
+    "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-markdown.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-markdown.py
@@ -1,0 +1,125 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample uploads Markdown input, then calls /pdf with a JSON payload.
+# It demonstrates structured_text_options, tagged Markdown image mapping, and input/output resource IDs.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.md"
+image_path = sys.argv[2] if len(sys.argv) > 2 else "/path/to/logo.png"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+
+def upload(path):
+    with open(path, "rb") as source:
+        response = requests.post(api_url + "/upload", data=source, headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Filename": os.path.basename(path),
+            "Api-Key": api_key,
+        })
+    if not response.ok:
+        print(response.text)
+        raise SystemExit(1)
+    return response.json()["files"][0]["id"]
+
+input_id = upload(input_path)
+image_id = upload(image_path)
+payload = {
+    "id": input_id,
+    "structured_text_options": json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "markdown": {
+    "image_alt_text": {
+      "sample-logo": "Sample logo"
+    },
+    "missing_image_alt_text": "fail",
+    "image_sources": {
+      "sample-logo": {
+        "image_id_index": 0
+      }
+    }
+  }
+}'''),
+}
+payload["image_ids"] = [image_id]
+response = requests.post(api_url + "/pdf", json=payload, headers={
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Api-Key": api_key,
+})
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-text.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-text.py
@@ -1,22 +1,24 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample uploads plain text input, then calls /pdf with a JSON payload.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.txt"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.text"
 
 def upload(path):
     with open(path, "rb") as source:
         response = requests.post(api_url + "/upload", data=source, headers={
             "Content-Type": "application/octet-stream",
             "Content-Filename": os.path.basename(path),
-            "Api-Key": api_key,
+            "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         })
     if not response.ok:
         print(response.text)
@@ -102,7 +104,7 @@ payload = {
 response = requests.post(api_url + "/pdf", json=payload, headers={
     "Accept": "application/json",
     "Content-Type": "application/json",
-    "Api-Key": api_key,
+    "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-text.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-text.py
@@ -11,7 +11,7 @@ api_url = "https://api.pdfrest.com"
 
 # This sample uploads plain text input, then calls /pdf with a JSON payload.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = "/path/to/sample.text"
+input_path = "/path/to/sample.txt"
 
 def upload(path):
     with open(path, "rb") as source:
@@ -113,4 +113,3 @@ if response.ok:
 else:
     print(response.text)
     raise SystemExit(1)
-

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-text.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-text.py
@@ -1,0 +1,114 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample uploads plain text input, then calls /pdf with a JSON payload.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.txt"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+
+def upload(path):
+    with open(path, "rb") as source:
+        response = requests.post(api_url + "/upload", data=source, headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Filename": os.path.basename(path),
+            "Api-Key": api_key,
+        })
+    if not response.ok:
+        print(response.text)
+        raise SystemExit(1)
+    return response.json()["files"][0]["id"]
+
+input_id = upload(input_path)
+payload = {
+    "id": input_id,
+    "structured_text_options": json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "plain_text": {
+    "line_handling": "preserve"
+  }
+}'''),
+}
+response = requests.post(api_url + "/pdf", json=payload, headers={
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Api-Key": api_key,
+})
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-xml.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-xml.py
@@ -1,22 +1,24 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample uploads XML input, then calls /pdf with a JSON payload.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.xml"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.xml"
 
 def upload(path):
     with open(path, "rb") as source:
         response = requests.post(api_url + "/upload", data=source, headers={
             "Content-Type": "application/octet-stream",
             "Content-Filename": os.path.basename(path),
-            "Api-Key": api_key,
+            "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         })
     if not response.ok:
         print(response.text)
@@ -100,7 +102,7 @@ payload = {
 response = requests.post(api_url + "/pdf", json=payload, headers={
     "Accept": "application/json",
     "Content-Type": "application/json",
-    "Api-Key": api_key,
+    "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/JSON Payload/pdf-from-xml.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-from-xml.py
@@ -1,0 +1,112 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample uploads XML input, then calls /pdf with a JSON payload.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.xml"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+
+def upload(path):
+    with open(path, "rb") as source:
+        response = requests.post(api_url + "/upload", data=source, headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Filename": os.path.basename(path),
+            "Api-Key": api_key,
+        })
+    if not response.ok:
+        print(response.text)
+        raise SystemExit(1)
+    return response.json()["files"][0]["id"]
+
+input_id = upload(input_path)
+payload = {
+    "id": input_id,
+    "structured_text_options": json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "data_presentation": "hierarchy"
+}'''),
+}
+response = requests.post(api_url + "/pdf", json=payload, headers={
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Api-Key": api_key,
+})
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-csv.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-csv.py
@@ -1,15 +1,17 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample converts CSV input to a tagged PDF through multipart /pdf.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.csv"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.csv"
 options = json.loads(r'''{
   "title": "Structured Content Sample",
   "language": "en-US",
@@ -111,7 +113,7 @@ with open(input_path, "rb") as input_file:
     response = requests.post(api_url + "/pdf", data=form, headers={
         "Accept": "application/json",
         "Content-Type": form.content_type,
-        "Api-Key": api_key,
+        "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-csv.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-csv.py
@@ -1,0 +1,123 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample converts CSV input to a tagged PDF through multipart /pdf.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.csv"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+options = json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "csv": {
+    "first_row_is_header": true,
+    "delimiter": ",",
+    "columns": [
+      {
+        "index": 0,
+        "width_weight": 2,
+        "text_align": "left"
+      },
+      {
+        "index": 1,
+        "width_weight": 3,
+        "text_align": "left"
+      },
+      {
+        "index": 2,
+        "width_weight": 1,
+        "text_align": "right"
+      }
+    ]
+  }
+}''')
+
+from requests_toolbelt import MultipartEncoder
+with open(input_path, "rb") as input_file:
+    fields = {
+        "file": (os.path.basename(input_path), input_file, "text/plain"),
+        "structured_text_options": json.dumps(options),
+    }
+    form = MultipartEncoder(fields=fields)
+    response = requests.post(api_url + "/pdf", data=form, headers={
+        "Accept": "application/json",
+        "Content-Type": form.content_type,
+        "Api-Key": api_key,
+    })
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-json.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-json.py
@@ -1,0 +1,103 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample converts JSON input to a tagged PDF through multipart /pdf.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.json"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+options = json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "data_presentation": "hierarchy"
+}''')
+
+from requests_toolbelt import MultipartEncoder
+with open(input_path, "rb") as input_file:
+    fields = {
+        "file": (os.path.basename(input_path), input_file, "text/plain"),
+        "structured_text_options": json.dumps(options),
+    }
+    form = MultipartEncoder(fields=fields)
+    response = requests.post(api_url + "/pdf", data=form, headers={
+        "Accept": "application/json",
+        "Content-Type": form.content_type,
+        "Api-Key": api_key,
+    })
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-json.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-json.py
@@ -1,15 +1,17 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample converts JSON input to a tagged PDF through multipart /pdf.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.json"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.json"
 options = json.loads(r'''{
   "title": "Structured Content Sample",
   "language": "en-US",
@@ -91,7 +93,7 @@ with open(input_path, "rb") as input_file:
     response = requests.post(api_url + "/pdf", data=form, headers={
         "Accept": "application/json",
         "Content-Type": form.content_type,
-        "Api-Key": api_key,
+        "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-markdown.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-markdown.py
@@ -1,0 +1,115 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample converts Markdown input to a tagged PDF through multipart /pdf.
+# It demonstrates structured_text_options, table styling, tagging, and uploaded Markdown image mapping.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.md"
+image_path = sys.argv[2] if len(sys.argv) > 2 else "/path/to/logo.png"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+options = json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "markdown": {
+    "image_alt_text": {
+      "sample-logo": "Sample logo"
+    },
+    "missing_image_alt_text": "fail",
+    "image_sources": {
+      "sample-logo": {
+        "upload_index": 0
+      }
+    }
+  }
+}''')
+
+from requests_toolbelt import MultipartEncoder
+with open(input_path, "rb") as input_file, open(image_path, "rb") as image_file:
+    fields = {
+        "file": (os.path.basename(input_path), input_file, "text/plain"),
+        "structured_text_options": json.dumps(options),
+        "image_files": (os.path.basename(image_path), image_file, "image/png"),
+    }
+    form = MultipartEncoder(fields=fields)
+    response = requests.post(api_url + "/pdf", data=form, headers={
+        "Accept": "application/json",
+        "Content-Type": form.content_type,
+        "Api-Key": api_key,
+    })
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-markdown.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-markdown.py
@@ -1,16 +1,18 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample converts Markdown input to a tagged PDF through multipart /pdf.
 # It demonstrates structured_text_options, table styling, tagging, and uploaded Markdown image mapping.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.md"
-image_path = sys.argv[2] if len(sys.argv) > 2 else "/path/to/logo.png"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.md"
+image_path = "/path/to/logo.png"
 options = json.loads(r'''{
   "title": "Structured Content Sample",
   "language": "en-US",
@@ -103,7 +105,7 @@ with open(input_path, "rb") as input_file, open(image_path, "rb") as image_file:
     response = requests.post(api_url + "/pdf", data=form, headers={
         "Accept": "application/json",
         "Content-Type": form.content_type,
-        "Api-Key": api_key,
+        "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-text.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-text.py
@@ -1,0 +1,105 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample converts plain text input to a tagged PDF through multipart /pdf.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.txt"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+options = json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "plain_text": {
+    "line_handling": "preserve"
+  }
+}''')
+
+from requests_toolbelt import MultipartEncoder
+with open(input_path, "rb") as input_file:
+    fields = {
+        "file": (os.path.basename(input_path), input_file, "text/plain"),
+        "structured_text_options": json.dumps(options),
+    }
+    form = MultipartEncoder(fields=fields)
+    response = requests.post(api_url + "/pdf", data=form, headers={
+        "Accept": "application/json",
+        "Content-Type": form.content_type,
+        "Api-Key": api_key,
+    })
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-text.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-text.py
@@ -11,7 +11,7 @@ api_url = "https://api.pdfrest.com"
 
 # This sample converts plain text input to a tagged PDF through multipart /pdf.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = "/path/to/sample.text"
+input_path = "/path/to/sample.txt"
 options = json.loads(r'''{
   "title": "Structured Content Sample",
   "language": "en-US",
@@ -104,4 +104,3 @@ if response.ok:
 else:
     print(response.text)
     raise SystemExit(1)
-

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-text.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-text.py
@@ -1,15 +1,17 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample converts plain text input to a tagged PDF through multipart /pdf.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.txt"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.text"
 options = json.loads(r'''{
   "title": "Structured Content Sample",
   "language": "en-US",
@@ -93,7 +95,7 @@ with open(input_path, "rb") as input_file:
     response = requests.post(api_url + "/pdf", data=form, headers={
         "Accept": "application/json",
         "Content-Type": form.content_type,
-        "Api-Key": api_key,
+        "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     })
 
 print("Response status code: " + str(response.status_code))

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-xml.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-xml.py
@@ -1,0 +1,103 @@
+import json
+import os
+import sys
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+
+# This sample converts XML input to a tagged PDF through multipart /pdf.
+# It demonstrates structured_text_options and the format-specific conversion options.
+input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.xml"
+api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+options = json.loads(r'''{
+  "title": "Structured Content Sample",
+  "language": "en-US",
+  "enable_tagging": true,
+  "page_setup": {
+    "size": "Letter",
+    "orientation": "portrait",
+    "margin": {
+      "top": 36,
+      "right": 42,
+      "bottom": 36,
+      "left": 42
+    }
+  },
+  "style": {
+    "font": "Arial",
+    "heading_font": "Arial",
+    "code_font": "Courier",
+    "text_size": 11,
+    "text_color_rgb": [
+      34,
+      34,
+      34
+    ],
+    "heading_scale": 1.35,
+    "table": {
+      "column_width_weights": [
+        2,
+        3,
+        2
+      ],
+      "keep_header_with_first_row": true,
+      "repeat_headers_on_overflow": true,
+      "show_borders": true,
+      "border_width": 0.75,
+      "border_color_rgb": [
+        180,
+        188,
+        200
+      ],
+      "header_fill_color_rgb": [
+        33,
+        64,
+        98
+      ],
+      "header_text_color_rgb": [
+        255,
+        255,
+        255
+      ],
+      "row_fill_color_rgb": [
+        250,
+        250,
+        252
+      ],
+      "alternate_row_fill_color_rgb": [
+        235,
+        240,
+        246
+      ],
+      "cell_padding": {
+        "top": 6,
+        "right": 8,
+        "bottom": 6,
+        "left": 8
+      }
+    }
+  },
+  "data_presentation": "hierarchy"
+}''')
+
+from requests_toolbelt import MultipartEncoder
+with open(input_path, "rb") as input_file:
+    fields = {
+        "file": (os.path.basename(input_path), input_file, "text/plain"),
+        "structured_text_options": json.dumps(options),
+    }
+    form = MultipartEncoder(fields=fields)
+    response = requests.post(api_url + "/pdf", data=form, headers={
+        "Accept": "application/json",
+        "Content-Type": form.content_type,
+        "Api-Key": api_key,
+    })
+
+print("Response status code: " + str(response.status_code))
+if response.ok:
+    print(json.dumps(response.json(), indent=2))
+else:
+    print(response.text)
+    raise SystemExit(1)
+

--- a/Python/Endpoint Examples/Multipart Payload/pdf-from-xml.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-from-xml.py
@@ -1,15 +1,17 @@
 import json
 import os
-import sys
 import requests
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-api_url = os.environ.get("PDFREST_URL", "https://api.pdfrest.com")
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+#api_url = "https://eu-api.pdfrest.com"
 
 # This sample converts XML input to a tagged PDF through multipart /pdf.
 # It demonstrates structured_text_options and the format-specific conversion options.
-input_path = sys.argv[1] if len(sys.argv) > 1 else "/path/to/sample.xml"
-api_key = os.environ.get("PDFREST_API_KEY", "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+input_path = "/path/to/sample.xml"
 options = json.loads(r'''{
   "title": "Structured Content Sample",
   "language": "en-US",
@@ -91,7 +93,7 @@ with open(input_path, "rb") as input_file:
     response = requests.post(api_url + "/pdf", data=form, headers={
         "Accept": "application/json",
         "Content-Type": form.content_type,
-        "Api-Key": api_key,
+        "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     })
 
 print("Response status code: " + str(response.status_code))

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-csv.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-csv.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts CSV input to a tagged PDF through the JSON /pdf flow.
-INPUT_PATH="${1:-/path/to/sample.csv}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.csv"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}'
 
 INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --header "Content-Filename: $(basename "$INPUT_PATH")" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
@@ -19,5 +22,5 @@ PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-csv.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-csv.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts CSV input to a tagged PDF through the JSON /pdf flow.
+INPUT_PATH="${1:-/path/to/sample.csv}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}'
+
+INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
+  --header "Api-Key: $API_KEY" \
+  --header "Content-Filename: $(basename "$INPUT_PATH")" \
+  --header "Content-Type: application/octet-stream" \
+  --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
+if [ -z "$INPUT_ID" ] || [ "$INPUT_ID" = "null" ]; then echo "Input upload failed" >&2; exit 1; fi
+PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
+  '{"id": $id, "structured_text_options": $options}')
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --header "Api-Key: $API_KEY" \
+  --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-json.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-json.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts JSON input to a tagged PDF through the JSON /pdf flow.
+INPUT_PATH="${1:-/path/to/sample.json}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
+
+INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
+  --header "Api-Key: $API_KEY" \
+  --header "Content-Filename: $(basename "$INPUT_PATH")" \
+  --header "Content-Type: application/octet-stream" \
+  --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
+if [ -z "$INPUT_ID" ] || [ "$INPUT_ID" = "null" ]; then echo "Input upload failed" >&2; exit 1; fi
+PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
+  '{"id": $id, "structured_text_options": $options}')
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --header "Api-Key: $API_KEY" \
+  --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-json.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-json.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts JSON input to a tagged PDF through the JSON /pdf flow.
-INPUT_PATH="${1:-/path/to/sample.json}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.json"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
 
 INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --header "Content-Filename: $(basename "$INPUT_PATH")" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
@@ -19,5 +22,5 @@ PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-markdown.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-markdown.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts Markdown input to a tagged PDF through the JSON /pdf flow.
+# It maps a Markdown image target to an uploaded image resource.
+INPUT_PATH="${1:-/path/to/sample.md}"
+IMAGE_PATH="${2:-/path/to/logo.png}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"image_id_index":0}}}}'
+
+INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
+  --header "Api-Key: $API_KEY" \
+  --header "Content-Filename: $(basename "$INPUT_PATH")" \
+  --header "Content-Type: application/octet-stream" \
+  --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
+if [ -z "$INPUT_ID" ] || [ "$INPUT_ID" = "null" ]; then echo "Input upload failed" >&2; exit 1; fi
+IMAGE_ID=$(curl --silent --show-error --location "$API_URL/upload" \
+  --header "Api-Key: $API_KEY" \
+  --header "Content-Filename: $(basename "$IMAGE_PATH")" \
+  --header "Content-Type: application/octet-stream" \
+  --data-binary "@$IMAGE_PATH" | jq -r ".files[0].id")
+if [ -z "$IMAGE_ID" ] || [ "$IMAGE_ID" = "null" ]; then echo "Image upload failed" >&2; exit 1; fi
+PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" --arg image_id "$IMAGE_ID" \
+  '{"id": $id, "structured_text_options": $options, "image_ids": [$image_id]}')
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --header "Api-Key: $API_KEY" \
+  --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-markdown.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-markdown.sh
@@ -1,23 +1,26 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts Markdown input to a tagged PDF through the JSON /pdf flow.
 # It maps a Markdown image target to an uploaded image resource.
-INPUT_PATH="${1:-/path/to/sample.md}"
-IMAGE_PATH="${2:-/path/to/logo.png}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.md"
+IMAGE_PATH="/path/to/logo.png"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"image_id_index":0}}}}'
 
 INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --header "Content-Filename: $(basename "$INPUT_PATH")" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
 if [ -z "$INPUT_ID" ] || [ "$INPUT_ID" = "null" ]; then echo "Input upload failed" >&2; exit 1; fi
 IMAGE_ID=$(curl --silent --show-error --location "$API_URL/upload" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --header "Content-Filename: $(basename "$IMAGE_PATH")" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@$IMAGE_PATH" | jq -r ".files[0].id")
@@ -27,5 +30,5 @@ PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" --arg image_id
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-text.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-text.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts plain text input to a tagged PDF through the JSON /pdf flow.
+INPUT_PATH="${1:-/path/to/sample.txt}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}'
+
+INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
+  --header "Api-Key: $API_KEY" \
+  --header "Content-Filename: $(basename "$INPUT_PATH")" \
+  --header "Content-Type: application/octet-stream" \
+  --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
+if [ -z "$INPUT_ID" ] || [ "$INPUT_ID" = "null" ]; then echo "Input upload failed" >&2; exit 1; fi
+PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
+  '{"id": $id, "structured_text_options": $options}')
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --header "Api-Key: $API_KEY" \
+  --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-text.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-text.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts plain text input to a tagged PDF through the JSON /pdf flow.
-INPUT_PATH="${1:-/path/to/sample.txt}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.txt"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}'
 
 INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --header "Content-Filename: $(basename "$INPUT_PATH")" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
@@ -19,5 +22,5 @@ PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-xml.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-xml.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts XML input to a tagged PDF through the JSON /pdf flow.
-INPUT_PATH="${1:-/path/to/sample.xml}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.xml"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
 
 INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --header "Content-Filename: $(basename "$INPUT_PATH")" \
   --header "Content-Type: application/octet-stream" \
   --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
@@ -19,5 +22,5 @@ PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/JSON Payload/pdf-from-xml.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-from-xml.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts XML input to a tagged PDF through the JSON /pdf flow.
+INPUT_PATH="${1:-/path/to/sample.xml}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
+
+INPUT_ID=$(curl --silent --show-error --location "$API_URL/upload" \
+  --header "Api-Key: $API_KEY" \
+  --header "Content-Filename: $(basename "$INPUT_PATH")" \
+  --header "Content-Type: application/octet-stream" \
+  --data-binary "@$INPUT_PATH" | jq -r ".files[0].id")
+if [ -z "$INPUT_ID" ] || [ "$INPUT_ID" = "null" ]; then echo "Input upload failed" >&2; exit 1; fi
+PAYLOAD=$(jq -n --arg id "$INPUT_ID" --argjson options "$OPTIONS" \
+  '{"id": $id, "structured_text_options": $options}')
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --header "Api-Key: $API_KEY" \
+  --data "$PAYLOAD"

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-csv.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-csv.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts CSV input to a tagged PDF through multipart /pdf.
-INPUT_PATH="${1:-/path/to/sample.csv}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.csv"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}'
 
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: multipart/form-data" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --form "file=@$INPUT_PATH" \
   --form "structured_text_options=$OPTIONS" \
   --form "output=pdf_from_csv"

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-csv.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-csv.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts CSV input to a tagged PDF through multipart /pdf.
+INPUT_PATH="${1:-/path/to/sample.csv}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"csv":{"first_row_is_header":true,"delimiter":",","columns":[{"index":0,"width_weight":2,"text_align":"left"},{"index":1,"width_weight":3,"text_align":"left"},{"index":2,"width_weight":1,"text_align":"right"}]}}'
+
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: multipart/form-data" \
+  --header "Api-Key: $API_KEY" \
+  --form "file=@$INPUT_PATH" \
+  --form "structured_text_options=$OPTIONS" \
+  --form "output=pdf_from_csv"
+

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-json.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-json.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts JSON input to a tagged PDF through multipart /pdf.
-INPUT_PATH="${1:-/path/to/sample.json}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.json"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
 
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: multipart/form-data" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --form "file=@$INPUT_PATH" \
   --form "structured_text_options=$OPTIONS" \
   --form "output=pdf_from_json"

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-json.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-json.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts JSON input to a tagged PDF through multipart /pdf.
+INPUT_PATH="${1:-/path/to/sample.json}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
+
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: multipart/form-data" \
+  --header "Api-Key: $API_KEY" \
+  --form "file=@$INPUT_PATH" \
+  --form "structured_text_options=$OPTIONS" \
+  --form "output=pdf_from_json"
+

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-markdown.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-markdown.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts Markdown input to a tagged PDF through multipart /pdf.
+# It maps a Markdown image target to an uploaded image resource.
+INPUT_PATH="${1:-/path/to/sample.md}"
+IMAGE_PATH="${2:-/path/to/logo.png}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"upload_index":0}}}}'
+
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: multipart/form-data" \
+  --header "Api-Key: $API_KEY" \
+  --form "file=@$INPUT_PATH" \
+  --form "image_files=@$IMAGE_PATH" \
+  --form "structured_text_options=$OPTIONS" \
+  --form "output=pdf_from_markdown"
+

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-markdown.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-markdown.sh
@@ -1,19 +1,22 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts Markdown input to a tagged PDF through multipart /pdf.
 # It maps a Markdown image target to an uploaded image resource.
-INPUT_PATH="${1:-/path/to/sample.md}"
-IMAGE_PATH="${2:-/path/to/logo.png}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.md"
+IMAGE_PATH="/path/to/logo.png"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"markdown":{"image_alt_text":{"sample-logo":"Sample logo"},"missing_image_alt_text":"fail","image_sources":{"sample-logo":{"upload_index":0}}}}'
 
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: multipart/form-data" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --form "file=@$INPUT_PATH" \
   --form "image_files=@$IMAGE_PATH" \
   --form "structured_text_options=$OPTIONS" \

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-text.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-text.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts plain text input to a tagged PDF through multipart /pdf.
-INPUT_PATH="${1:-/path/to/sample.txt}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.txt"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}'
 
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: multipart/form-data" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --form "file=@$INPUT_PATH" \
   --form "structured_text_options=$OPTIONS" \
   --form "output=pdf_from_text"

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-text.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-text.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts plain text input to a tagged PDF through multipart /pdf.
+INPUT_PATH="${1:-/path/to/sample.txt}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"plain_text":{"line_handling":"preserve"}}'
+
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: multipart/form-data" \
+  --header "Api-Key: $API_KEY" \
+  --form "file=@$INPUT_PATH" \
+  --form "structured_text_options=$OPTIONS" \
+  --form "output=pdf_from_text"
+

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-xml.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-xml.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
 
 # By default, we use the US-based API service. This is the primary endpoint for global use.
-API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
 
 # This sample converts XML input to a tagged PDF through multipart /pdf.
-INPUT_PATH="${1:-/path/to/sample.xml}"
-API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+INPUT_PATH="/path/to/sample.xml"
 OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
 
 curl --location "$API_URL/pdf" \
   --header "Accept: application/json" \
   --header "Content-Type: multipart/form-data" \
-  --header "Api-Key: $API_KEY" \
+  --header "Api-Key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
   --form "file=@$INPUT_PATH" \
   --form "structured_text_options=$OPTIONS" \
   --form "output=pdf_from_xml"

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-from-xml.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-from-xml.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="${PDFREST_URL:-https://api.pdfrest.com}"
+
+# This sample converts XML input to a tagged PDF through multipart /pdf.
+INPUT_PATH="${1:-/path/to/sample.xml}"
+API_KEY="${PDFREST_API_KEY:-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
+OPTIONS='{"title":"Structured Content Sample","language":"en-US","enable_tagging":true,"page_setup":{"size":"Letter","orientation":"portrait","margin":{"top":36,"right":42,"bottom":36,"left":42}},"style":{"font":"Arial","heading_font":"Arial","code_font":"Courier","text_size":11,"text_color_rgb":[34,34,34],"heading_scale":1.35,"table":{"column_width_weights":[2,3,2],"keep_header_with_first_row":true,"repeat_headers_on_overflow":true,"show_borders":true,"border_width":0.75,"border_color_rgb":[180,188,200],"header_fill_color_rgb":[33,64,98],"header_text_color_rgb":[255,255,255],"row_fill_color_rgb":[250,250,252],"alternate_row_fill_color_rgb":[235,240,246],"cell_padding":{"top":6,"right":8,"bottom":6,"left":8}}},"data_presentation":"hierarchy"}'
+
+curl --location "$API_URL/pdf" \
+  --header "Accept: application/json" \
+  --header "Content-Type: multipart/form-data" \
+  --header "Api-Key: $API_KEY" \
+  --form "file=@$INPUT_PATH" \
+  --form "structured_text_options=$OPTIONS" \
+  --form "output=pdf_from_xml"
+


### PR DESCRIPTION
## Why this change

The Convert to PDF endpoint now supports structured text inputs, but the endpoint examples did not yet make those workflows easy to discover across the primary languages. This change gives developers complete examples for the supported structured formats and shows how to use the same endpoint with either an uploaded file or a previously uploaded resource.

## What changed

Added endpoint examples for Markdown, CSV, JSON, XML, and plain text in cURL, Python, JavaScript, PHP, Java, and .NET. Each format has both JSON-resource and multipart examples.

The Markdown examples include page setup, styling, table formatting, tagged output, and image mapping. The JSON-resource variant uploads the Markdown image first and maps it through `image_ids`; the multipart variant maps an uploaded image through `image_files`. The .NET dispatcher includes commands for all new examples.

## Behavior changes

The JSON-resource examples upload the source file before calling `/pdf` and pass the resulting resource ID in the JSON payload. Multipart examples send the source file and `structured_text_options` in one `/pdf` request. All examples print the API response, including output and input resource IDs where returned.

The examples enable tagging so the generated PDFs demonstrate tagged output. Format-specific options are limited to the formats where they apply: Markdown image mapping, CSV table configuration, JSON/XML hierarchy presentation, and plain-text line preservation.

## Validation

All 60 examples were executed against the pdfRest service using the same five representative inputs. Every request succeeded. The 60 returned PDFs passed `qpdf --check`, and extracted text matched across all six languages and both payload styles for each format. Representative Markdown, CSV, JSON, XML, and plain-text PDFs were rendered and visually inspected.

Static validation passed for Python, JavaScript, cURL, PHP, .NET, and Java. No secrets or machine-specific paths are included.

## Risks and follow-ups

There are no API behavior or compatibility changes in this repository; this PR adds examples only. The cURL, Python, JavaScript, and PHP samples follow the established endpoint-example convention of using placeholder API keys and local paths in the source. Java retains the existing default API-key constant with optional dotenv lookup, and .NET retains its repository-standard environment-variable configuration and dispatcher arguments. Users replace the placeholders before running the samples.
